### PR TITLE
feat(post-cursor): 添加上下页排序选项

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -555,6 +555,17 @@ spec:
           min: 1
           max: 50
           validation: required
+        - $formkit: radio
+          name: cursor
+          id: cursor
+          label: 上下页排序
+          value: true
+          help: 倒序：从旧到新；正序：从新到旧。
+          options:
+            - value: true
+              label: 倒序
+            - value: false
+              label: 正序
         - $formkit: checkbox
           name: default_cover
           id: default_cover

--- a/templates/post.html
+++ b/templates/post.html
@@ -4,7 +4,10 @@
   th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = null)}"
 >
   <th:block th:fragment="content">
-    <div class="post-header" th:classappend="${(post.spec.cover != null and post.spec.cover != '' ? 'has-cover ' : '') + (theme.config.post.center_title ? 'center-title' : '')}">
+    <div
+      class="post-header"
+      th:classappend="${(post.spec.cover != null and post.spec.cover != '' ? 'has-cover ' : '') + (theme.config.post.center_title ? 'center-title' : '')}"
+    >
       <img th:if="${post.spec.cover}" th:src="${post.spec.cover}" class="post-cover" th:alt="${post.spec.title}" />
 
       <div class="post-nav">
@@ -204,8 +207,9 @@
 
     <th:block
       th:with="
-        prevPost = ${postFinder.cursor(post.metadata.name).previous},
-        nextPost = ${postFinder.cursor(post.metadata.name).next}
+        cursor = ${postFinder.cursor(post.metadata.name)},
+        prevPost = ${theme.config.post.cursor ? cursor.previous : cursor.next},
+        nextPost = ${theme.config.post.cursor ? cursor.next : cursor.previous}
       "
     >
       <div th:if="${prevPost != null or nextPost != null}" class="surround-post">


### PR DESCRIPTION
在文章设置中增加排序方向选项，支持正序或倒序浏览文章

之前文章的上下页是：左边为新，右边为旧（版本：2.21.10）

<img width="983" height="149" alt="Image" src="https://github.com/user-attachments/assets/78b627ae-05f6-4677-aee9-f311f41a8e64" />

现在文章的上下页是：左边为旧，右边为新（版本：2.22.0）

<img width="995" height="194" alt="Image" src="https://github.com/user-attachments/assets/a993f92b-c7a0-4f7b-9c38-d07509eb2038" />

现在可以自由选择。

[文章 Finder API > 修改 cursor(postName) 返回结构](https://docs.halo.run/developer-guide/theme/api-changelog/#%E6%96%87%E7%AB%A0-finder-api--%E4%BF%AE%E6%94%B9-cursorpostname-%E8%BF%94%E5%9B%9E%E7%BB%93%E6%9E%84)