### PR TITLE
feat(img-alt): 添加图片 alt 文本显示切换功能

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -826,6 +826,11 @@ spec:
               label: 竖线（页面 | 网站）
             - value: "across"
               label: 横线（页面 - 网站）
+        - $formkit: checkbox
+          name: img_alt
+          label: 启用图片 alt 文本
+          value: true
+          help: 开启后图片将显示 alt 文本
     - group: development
       label: 开发设置
       formSchema:

--- a/src/main.ts
+++ b/src/main.ts
@@ -312,26 +312,29 @@ function initImageLoaded() {
 
 // 为文章图片添加描述显示
 function initImageCaption() {
+  // 检查是否启用图片 alt 文本功能
+  if (!(window as any).themeConfig?.custom?.img_alt) return;
+
   const article = document.querySelector(".article");
   if (!article) return;
-  
+
   const images = article.querySelectorAll("img");
   if (!images.length) return;
-  
+
   images.forEach((img) => {
     const alt = img.alt?.trim();
     if (!alt) return;
-    
+
     // 跳过 c-pic/gallery 中的图片
     if (img.closest(".c-pic, [data-type='gallery']")) return;
-    
+
     // 检查现有 figure
     const figure = img.closest("figure");
     if (figure?.querySelector("figcaption")) return;
-    
+
     const caption = document.createElement("figcaption");
     caption.textContent = alt;
-    
+
     if (figure) {
       figure.classList.add("img-caption");
       figure.appendChild(caption);
@@ -435,4 +438,3 @@ function initBackToTop() {
     });
   }
 }
-

--- a/templates/modules/layout.html
+++ b/templates/modules/layout.html
@@ -60,6 +60,11 @@
         }
       })();
     </script>
+    <script th:inline="javascript">
+      window.themeConfig = window.themeConfig || {};
+      window.themeConfig.custom = window.themeConfig.custom || {};
+      window.themeConfig.custom.img_alt = /*[[${theme.config.custom.img_alt}]]*/ false;
+    </script>
   </head>
   <body id="clarity-root">
     <div


### PR DESCRIPTION
## 预览

默认启用

### 关闭

<img width="2482" height="1289" alt="image" src="https://github.com/user-attachments/assets/ae36c26b-c9f3-4bf8-b07f-a82053013538" />

### 开启
<img width="2482" height="1289" alt="image" src="https://github.com/user-attachments/assets/be9dc5cf-f0a0-4154-b330-cb52c44c6f95" />
