### PR TITLE
fix(post.html): 修复封面图片为空时的显示问题

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -1,8 +1,19 @@
 <!doctype html>
-<html xmlns:th="https://www.thymeleaf.org" th:replace="~{modules/layout :: html(content = ~{::content}, showAside = false, pageTitle = null)}">
+<html
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = false, pageTitle = null)}"
+>
   <th:block th:fragment="content">
-    <div class="post-header" th:classappend="${(singlePage.spec.cover != null and singlePage.spec.cover != '' ? 'has-cover ' : '') + (theme.config.post.center_title ? 'center-title' : '')}">
-      <img th:if="${singlePage.spec.cover}" th:src="${singlePage.spec.cover}" class="post-cover" th:alt="${singlePage.spec.title}" />
+    <div
+      class="post-header"
+      th:classappend="${(singlePage.spec.cover != null and singlePage.spec.cover != '' ? 'has-cover ' : '') + (theme.config.post.center_title ? 'center-title' : '')}"
+    >
+      <img
+        th:if="${singlePage.spec.cover != null and singlePage.spec.cover  != ''}"
+        th:src="${singlePage.spec.cover}"
+        class="post-cover"
+        th:alt="${singlePage.spec.title}"
+      />
 
       <div class="post-nav">
         <div class="operations">
@@ -31,7 +42,7 @@
           </span>
         </div>
       </div>
-      
+
       <h1 class="post-title text-creative" th:text="${singlePage.spec.title}"></h1>
     </div>
 

--- a/templates/post.html
+++ b/templates/post.html
@@ -8,7 +8,12 @@
       class="post-header"
       th:classappend="${(post.spec.cover != null and post.spec.cover != '' ? 'has-cover ' : '') + (theme.config.post.center_title ? 'center-title' : '')}"
     >
-      <img th:if="${post.spec.cover}" th:src="${post.spec.cover}" class="post-cover" th:alt="${post.spec.title}" />
+      <img
+        th:if="${post.spec.cover != null and post.spec.cover != ''}"
+        th:src="${post.spec.cover}"
+        class="post-cover"
+        th:alt="${post.spec.title}"
+      />
 
       <div class="post-nav">
         <div class="operations">


### PR DESCRIPTION
Fix #30 

## 前

<img width="980" height="146" alt="image" src="https://github.com/user-attachments/assets/d5b9c59f-bed4-480a-aa7f-34f07aac38d0" />

## 后

<img width="980" height="152" alt="image" src="https://github.com/user-attachments/assets/a4a4baa6-98fe-4f9a-b5f6-a1f839cde718" />
