### PR TITLE
feat: 增加文章/页面编辑按钮

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -853,6 +853,13 @@ spec:
           label: 启用图片 alt 文本
           value: true
           help: 开启后图片将显示 alt 文本
+        - $formkit: switch
+          onValue: true
+          offValue: false
+          name: enable_edit
+          label: 启用编辑按钮
+          value: false
+          help: 开启后文章/页面将显示编辑按钮
     - group: development
       label: 开发设置
       formSchema:

--- a/src/styles/scss/components/_links.scss
+++ b/src/styles/scss/components/_links.scss
@@ -1,3 +1,5 @@
+@use "../reusable" as *;
+
 // ========================================
 // 友链页面样式 (Links Page)
 // 移植自 blog-v3-source
@@ -973,62 +975,5 @@ $breakpoint-phone: 528px !default;
 
 // PC端随机访问按钮 - 与返回顶部按钮风格一致
 .random-link-btn {
-  position: fixed;
-  right: 2.5rem;
-  bottom: calc(2.5rem + 60px); // 在返回顶部按钮上方
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  background-color: var(--ld-bg-card);
-  border: 1px solid var(--c-border);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-  cursor: pointer;
-  transition-duration: 0.3s;
-  overflow: hidden;
-  z-index: 99;
-  color: var(--c-text);
-  font-size: 1rem;
-
-  @media (max-width: 768px) {
-    display: none;
-  }
-
-  &::before {
-    position: absolute;
-    bottom: -20px;
-    content: "随机穿梭";
-    color: white;
-    font-size: 0px;
-    white-space: nowrap;
-  }
-
-  &:hover {
-    width: 120px;
-    border-radius: 50px;
-    background-color: var(--c-primary);
-    border-color: var(--c-primary);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
-    transition-duration: 0.3s;
-    transform: translateY(-4px);
-    color: white;
-
-    > span {
-      transition-duration: 0.3s;
-      transform: translateY(-200%);
-    }
-
-    &::before {
-      font-size: 13px;
-      opacity: 1;
-      bottom: unset;
-      transition-duration: 0.3s;
-    }
-  }
-
-  > span {
-    transition-duration: 0.3s;
-  }
+  @include floating-button("随机穿梭");
 }

--- a/src/styles/scss/components/_page.scss
+++ b/src/styles/scss/components/_page.scss
@@ -1,0 +1,12 @@
+@use "../reusable" as *;
+
+$breakpoint-mobile: 768px !default;
+
+// ========================================
+// 编辑按钮 (Edit Button)
+// ========================================
+
+// PC端编辑按钮 - 与返回顶部按钮风格一致
+.edit-page-btn {
+  @include floating-button("编辑页面");
+}

--- a/src/styles/scss/components/_post.scss
+++ b/src/styles/scss/components/_post.scss
@@ -1,3 +1,5 @@
+@use "../reusable" as *;
+
 $breakpoint-mobile: 768px !default;
 
 // ========================================
@@ -1308,4 +1310,11 @@ $breakpoint-mobile: 768px !default;
 		}
 	}
 }
+// ========================================
+// 编辑按钮 (Edit Button)
+// ========================================
 
+// PC端编辑按钮 - 与返回顶部按钮风格一致
+.edit-post-btn {
+  @include floating-button("编辑文章");
+}

--- a/src/styles/scss/reusable.scss
+++ b/src/styles/scss/reusable.scss
@@ -335,3 +335,67 @@ mark {
 	margin: 0 0.25em;
 	font-size: 0.85rem;
 }
+
+// ========================================
+// 浮动按钮 Mixin
+// ========================================
+@mixin floating-button($hover-text) {
+	position: fixed;
+	right: 2.5rem;
+	bottom: calc(2.5rem + 60px);
+	width: 50px;
+	height: 50px;
+	border-radius: 50%;
+	background-color: var(--ld-bg-card);
+	border: 1px solid var(--c-border);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+	cursor: pointer;
+	transition-duration: 0.3s;
+	overflow: hidden;
+	z-index: 99;
+	color: var(--c-text);
+	font-size: 1rem;
+
+	@media (max-width: $breakpoint-mobile) {
+		display: none;
+	}
+
+	&::before {
+		position: absolute;
+		bottom: -20px;
+		content: $hover-text;
+		color: white;
+		font-size: 0px;
+		white-space: nowrap;
+	}
+
+	&:hover {
+		width: 120px;
+		border-radius: 50px;
+		background-color: var(--c-primary);
+		border-color: var(--c-primary);
+		box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+		transition-duration: 0.3s;
+		transform: translateY(-4px);
+		color: white;
+
+		> span {
+			transition-duration: 0.3s;
+			transform: translateY(-200%);
+		}
+
+		&::before {
+			font-size: 13px;
+			opacity: 1;
+			bottom: unset;
+			transition-duration: 0.3s;
+		}
+	}
+
+	> span {
+		transition-duration: 0.3s;
+	}
+}

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -31,7 +31,8 @@ $breakpoint-widescreen: 1080px;
 );
 @use "./scss/components/slide";
 @use "./scss/components/image";
-@use "./scss/components/post" with (
+@use "./scss/components/post";
+@use "./scss/components/page" with (
   $breakpoint-mobile: $breakpoint-mobile
 );
 @use "./scss/components/comment";

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,8 +1,19 @@
 <!doctype html>
-<html xmlns:th="https://www.thymeleaf.org" th:replace="~{modules/layout :: html(content = ~{::content}, showAside = false, pageTitle = null)}">
+<html
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = false, pageTitle = null)}"
+>
   <th:block th:fragment="content">
-    <div class="post-header" th:classappend="${(singlePage.spec.cover != null and singlePage.spec.cover != '' ? 'has-cover ' : '') + (theme.config.post.center_title ? 'center-title' : '')}">
-      <img th:if="${singlePage.spec.cover}" th:src="${singlePage.spec.cover}" class="post-cover" th:alt="${singlePage.spec.title}" />
+    <div
+      class="post-header"
+      th:classappend="${(singlePage.spec.cover != null and singlePage.spec.cover != '' ? 'has-cover ' : '') + (theme.config.post.center_title ? 'center-title' : '')}"
+    >
+      <img
+        th:if="${singlePage.spec.cover}"
+        th:src="${singlePage.spec.cover}"
+        class="post-cover"
+        th:alt="${singlePage.spec.title}"
+      />
 
       <div class="post-nav">
         <div class="operations">
@@ -31,7 +42,7 @@
           </span>
         </div>
       </div>
-      
+
       <h1 class="post-title text-creative" th:text="${singlePage.spec.title}"></h1>
     </div>
 
@@ -44,7 +55,15 @@
     <section th:if="${haloCommentEnabled}" class="z-comment" id="comment">
       <halo:comment group="content.halo.run" kind="SinglePage" th:attr="name=${singlePage.metadata.name}" />
     </section>
-
+    <button
+      id="edit-page-btn"
+      class="edit-page-btn"
+      th:if="${#authentication.name == singlePage.owner.name}"
+      th:data-url="@{/console/single-pages/editor(name=${singlePage.metadata.name}, returnToView=true)}"
+      title="编辑页面"
+    >
+      <span class="icon-[ph--pencil-bold]"></span>
+    </button>
     <script th:inline="javascript">
       (function () {
         const shareBtn = document.getElementById("share-btn");
@@ -68,6 +87,16 @@
               }, 2000);
             } catch (err) {
               console.error("复制失败:", err);
+            }
+          });
+        }
+
+        const editPageBtn = document.getElementById("edit-page-btn");
+        if (editPageBtn) {
+          editPageBtn.addEventListener("click", () => {
+            const editUrl = editPageBtn.dataset.url;
+            if (editUrl) {
+              window.location.href = editUrl;
             }
           });
         }

--- a/templates/page.html
+++ b/templates/page.html
@@ -58,7 +58,7 @@
     <button
       id="edit-page-btn"
       class="edit-page-btn"
-      th:if="${#authentication.name == singlePage.owner.name}"
+      th:if="${theme.config.custom.enable_edit and #authentication.name == singlePage.owner.name}"
       th:data-url="@{/console/single-pages/editor(name=${singlePage.metadata.name}, returnToView=true)}"
       title="编辑页面"
     >

--- a/templates/post.html
+++ b/templates/post.html
@@ -250,7 +250,15 @@
     <section th:if="${haloCommentEnabled}" class="z-comment" id="comment">
       <halo:comment group="content.halo.run" kind="Post" th:attr="name=${post.metadata.name}" />
     </section>
-
+    <button
+      id="edit-post-btn"
+      class="edit-post-btn"
+      th:if="${#authentication.name == post.owner.name}"
+      th:data-url="@{${'/console/posts/editor'}(name=${post.metadata.name}, returnToView=true)}"
+      title="编辑文章"
+    >
+      <span class="icon-[ph--pencil-bold]"></span>
+    </button>
     <div id="poster-modal" class="poster-modal" style="display: none">
       <div class="poster-modal-overlay"></div>
       <div class="poster-modal-content">
@@ -336,6 +344,17 @@
         const posterDownload = document.getElementById("poster-download");
         const posterQrcode = document.getElementById("poster-qrcode");
         const posterCard = document.getElementById("poster-card");
+
+        // 编辑文章
+        const editPostBtn = document.getElementById("edit-post-btn");
+        if (editPostBtn) {
+          editPostBtn.addEventListener("click", () => {
+            const editUrl = editPostBtn.dataset.url;
+            if (editUrl) {
+              window.location.href = editUrl;
+            }
+          });
+        }
 
         if (posterBtn && posterModal) {
           let qrGenerated = false;

--- a/templates/post.html
+++ b/templates/post.html
@@ -253,7 +253,7 @@
     <button
       id="edit-post-btn"
       class="edit-post-btn"
-      th:if="${#authentication.name == post.owner.name}"
+      th:if="${theme.config.custom.enable_edit and #authentication.name == post.owner.name}"
       th:data-url="@{${'/console/posts/editor'}(name=${post.metadata.name}, returnToView=true)}"
       title="编辑文章"
     >


### PR DESCRIPTION
Fix #35 

## 功能

- 仅文章/页面拥有者可见编辑按钮
- 仅登录后可见编辑按钮
- 可配置显示与否，默认不显示

<img width="1301" height="724" alt="image" src="https://github.com/user-attachments/assets/1a706dab-2a28-4bf3-8624-9a76ce3a4a74" />

## 预览

### 未登录

<img width="2404" height="1344" alt="image" src="https://github.com/user-attachments/assets/cf7526c3-327c-4d59-b4e8-6bb4500a31e4" />


### 拥有者登录

<img width="2464" height="1289" alt="image" src="https://github.com/user-attachments/assets/ec80c91b-079a-402c-a966-47ff98513985" />

### 非拥有者登录

<img width="2404" height="1344" alt="image" src="https://github.com/user-attachments/assets/b112be64-cb9a-4745-b046-468a91b76ec2" />
