### PR TITLE
feat: 添加 toc 目录控制功能

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -53,6 +53,14 @@ spec:
     kind: Post
   formSchema:
     - $formkit: checkbox
+      id: toc
+      key: toc
+      name: toc
+      label: 目录
+      value: "true"
+      on-value: "true"
+      off-value: "false"
+    - $formkit: checkbox
       id: post_author
       key: post_author
       name: post_author
@@ -116,3 +124,21 @@ spec:
       key: post_license_url
       name: post_license_url
       label: 协议链接
+---
+apiVersion: v1alpha1
+kind: AnnotationSetting
+metadata:
+  generateName: annotation-setting-
+spec:
+  targetRef:
+    group: content.halo.run
+    kind: SinglePage
+  formSchema:
+    - $formkit: checkbox
+      id: toc
+      key: toc
+      name: toc
+      label: 目录
+      value: "false"
+      on-value: "true"
+      off-value: "false"

--- a/settings.yaml
+++ b/settings.yaml
@@ -861,7 +861,7 @@ spec:
         - $formkit: switch
           name: enable_page_toc
           label: 启用独立页面目录
-          value: true
+          value: false
           help: 开启后独立页面将显示目录
     - group: development
       label: 开发设置

--- a/settings.yaml
+++ b/settings.yaml
@@ -853,6 +853,16 @@ spec:
           label: 启用图片 alt 文本
           value: true
           help: 开启后图片将显示 alt 文本
+        - $formkit: switch
+          name: enable_post_toc
+          label: 启用文章目录
+          value: true
+          help: 开启后文章页面将显示目录
+        - $formkit: switch
+          name: enable_page_toc
+          label: 启用独立页面目录
+          value: true
+          help: 开启后独立页面将显示目录
     - group: development
       label: 开发设置
       formSchema:

--- a/templates/modules/aside.html
+++ b/templates/modules/aside.html
@@ -14,7 +14,7 @@
       class="widget toc-widget"
       id="catalog-widget"
       style="display: none"
-      th:if="${(post != null and theme.config.custom.enable_post_toc != false) or (singlePage != null and theme.config.custom.enable_page_toc != false)}"
+      th:if="${(post != null and theme.config.custom.enable_post_toc != false and #annotations.getOrDefault(post, 'toc', 'true') == 'true') or (singlePage != null and theme.config.custom.enable_page_toc != false and #annotations.getOrDefault(singlePage, 'toc', 'false') == 'true')}"
     >
       <hgroup class="widget-title">
         <span class="title-text">文章目录</span>

--- a/templates/modules/aside.html
+++ b/templates/modules/aside.html
@@ -10,7 +10,12 @@
 
 <aside th:fragment="aside" id="z-aside">
   <th:block th:if="${post != null or singlePage != null}">
-    <section class="widget toc-widget" id="catalog-widget" style="display: none">
+    <section
+      class="widget toc-widget"
+      id="catalog-widget"
+      style="display: none"
+      th:if="${(post != null and theme.config.custom.enable_post_toc != false) or (singlePage != null and theme.config.custom.enable_page_toc != false)}"
+    >
       <hgroup class="widget-title">
         <span class="title-text">文章目录</span>
         <a

--- a/templates/modules/aside.html
+++ b/templates/modules/aside.html
@@ -14,6 +14,7 @@
       <hgroup class="widget-title">
         <span class="title-text">文章目录</span>
         <a
+          th:if="${post != null}"
           onclick="return false;"
           aria-label="点赞文章"
           x-data="postLike()"

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = null)}"
+  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = ${theme.config.custom.enable_page_toc != false}, pageTitle = null)}"
 >
   <th:block th:fragment="content">
     <div

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = ${theme.config.custom.enable_page_toc != false}, pageTitle = null)}"
+  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = ${theme.config.custom.enable_page_toc != false and #annotations.getOrDefault(singlePage, 'toc', 'false') == 'true'}, pageTitle = null)}"
 >
   <th:block th:fragment="content">
     <div

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,8 +1,19 @@
 <!doctype html>
-<html xmlns:th="https://www.thymeleaf.org" th:replace="~{modules/layout :: html(content = ~{::content}, showAside = false, pageTitle = null)}">
+<html
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = null)}"
+>
   <th:block th:fragment="content">
-    <div class="post-header" th:classappend="${(singlePage.spec.cover != null and singlePage.spec.cover != '' ? 'has-cover ' : '') + (theme.config.post.center_title ? 'center-title' : '')}">
-      <img th:if="${singlePage.spec.cover}" th:src="${singlePage.spec.cover}" class="post-cover" th:alt="${singlePage.spec.title}" />
+    <div
+      class="post-header"
+      th:classappend="${(singlePage.spec.cover != null and singlePage.spec.cover != '' ? 'has-cover ' : '') + (theme.config.post.center_title ? 'center-title' : '')}"
+    >
+      <img
+        th:if="${singlePage.spec.cover}"
+        th:src="${singlePage.spec.cover}"
+        class="post-cover"
+        th:alt="${singlePage.spec.title}"
+      />
 
       <div class="post-nav">
         <div class="operations">
@@ -31,7 +42,7 @@
           </span>
         </div>
       </div>
-      
+
       <h1 class="post-title text-creative" th:text="${singlePage.spec.title}"></h1>
     </div>
 

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = null)}"
+  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = ${theme.config.custom.enable_post_toc != false}, pageTitle = null)}"
 >
   <th:block th:fragment="content">
     <div

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = ${theme.config.custom.enable_post_toc != false}, pageTitle = null)}"
+  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = ${theme.config.custom.enable_post_toc != false and #annotations.getOrDefault(post, 'toc', 'true') == 'true'}, pageTitle = null)}"
 >
   <th:block th:fragment="content">
     <div


### PR DESCRIPTION
## 功能

- 首先检查全局配置
- 然后检查单篇配置
- 两者都满足时才显示目录
- 开启全局配置后才能配置单篇

## 默认情况

- 文章目录默认开启
- 独立页面目录默认关闭

