### PR TITLE
feat(category-tag-layout): 添加分类和标签页布局切换功能

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -155,6 +155,16 @@ spec:
           label: 显示文章作者
           value: true
           help: 在首页文章卡片中显示作者头像和名称
+        - $formkit: switch
+          name: switch_category_layout
+          label: 切换分类文章样式布局
+          value: false
+          help: 切换分类页面的文章列表样式布局
+        - $formkit: switch
+          name: switch_tag_layout
+          label: 切换标签文章样式布局
+          value: false
+          help: 切换标签页面的文章列表样式布局
     - group: footer
       label: 页脚 & 社交
       formSchema:

--- a/templates/category.html
+++ b/templates/category.html
@@ -4,36 +4,15 @@
   th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = ${category.spec.displayName})}"
 >
   <th:block th:fragment="content">
-    <div class="category-page">
-      <header class="category-header card">
-        <div class="category-info">
-          <h1 class="category-title text-creative">
-            <span class="icon-[ph--folder-bold]"></span>
-            <span th:text="${category.spec.displayName}">分类名称</span>
-          </h1>
-          <p
-            th:if="${not #strings.isEmpty(category.spec.description)}"
-            class="category-description"
-            th:text="${category.spec.description}"
-          ></p>
-          <div class="category-meta">
-            <span class="meta-item">
-              <span class="icon-[ph--article-bold]"></span>
-              <span th:text="${category.postCount + ' 篇文章'}">0 篇文章</span>
-            </span>
-          </div>
-        </div>
-        <img
-          th:if="${not #strings.isEmpty(category.spec.cover)}"
-          th:src="${category.spec.cover}"
-          th:srcset="|${thumbnail.gen(category.spec.cover, 's')} 400w, ${thumbnail.gen(category.spec.cover, 'm')} 800w|"
-          sizes="200px"
-          class="category-cover"
-          th:alt="${category.spec.displayName}"
-        />
-      </header>
-
-      <th:block th:replace="~{modules/post-list :: list(posts=${posts}, caller='category')}" />
-    </div>
+    <th:block th:if="${theme.config.style.switch_category_layout == false}">
+      <th:block
+        th:replace="~{modules/category-layout-old :: layout(category=${category}, posts=${posts}, thumbnail=${thumbnail})}"
+      />
+    </th:block>
+    <th:block th:if="${theme.config.style.switch_category_layout == true}">
+      <th:block
+        th:replace="~{modules/category-layout-new :: layout(category=${category}, posts=${posts}, thumbnail=${thumbnail})}"
+      />
+    </th:block>
   </th:block>
 </html>

--- a/templates/modules/category-layout-new.html
+++ b/templates/modules/category-layout-new.html
@@ -1,0 +1,45 @@
+<th:block th:fragment="layout(category, posts, thumbnail)">
+  <div class="archive proper-height">
+    <header class="tag-header">
+      <a href="/categories" class="tag-back" title="返回分类列表">
+        <span class="icon-[ph--arrow-left-bold]"></span>
+        <span>分类列表</span>
+      </a>
+      <div class="tag-info">
+        <h1 class="tag-name">
+          <span class="icon-[ph--folder-bold]"></span><span th:text="${category.spec.displayName}"></span>
+        </h1>
+        <p class="tag-meta">共 <strong th:text="${posts.total}">0</strong> 篇文章</p>
+      </div>
+    </header>
+
+    <menu class="archive-list">
+      <li
+        th:each="post,postStat : ${posts.items}"
+        class="article-item"
+        th:style="'--delay: ' + ${postStat.index * 0.03} + 's'"
+      >
+        <time th:text="${#temporals.format(post.spec.publishTime, 'MM/dd')}"></time>
+        <a th:href="${post.status.permalink}" class="article-link gradient-card" th:title="${post.status.excerpt}">
+          <span class="article-title" th:text="${post.spec.title}"></span>
+          <img
+            th:if="${post.spec.cover}"
+            th:src="${post.spec.cover}"
+            th:srcset="|${thumbnail.gen(post.spec.cover, 's')} 400w|"
+            sizes="100px"
+            class="article-cover"
+            loading="lazy"
+            th:alt="${post.spec.title}"
+          />
+        </a>
+      </li>
+    </menu>
+
+    <div th:if="${#lists.isEmpty(posts.items)}" class="empty-state">
+      <span class="icon-[ph--article-bold]"></span>
+      <p>该分类下暂无文章</p>
+    </div>
+
+    <th:block th:replace="~{modules/pagination :: pagination(data=${posts})}" />
+  </div>
+</th:block>

--- a/templates/modules/category-layout-old.html
+++ b/templates/modules/category-layout-old.html
@@ -1,0 +1,33 @@
+<th:block th:fragment="layout(category, posts, thumbnail)">
+  <div class="category-page">
+    <header class="category-header card">
+      <div class="category-info">
+        <h1 class="category-title text-creative">
+          <span class="icon-[ph--folder-bold]"></span>
+          <span th:text="${category.spec.displayName}">分类名称</span>
+        </h1>
+        <p
+          th:if="${not #strings.isEmpty(category.spec.description)}"
+          class="category-description"
+          th:text="${category.spec.description}"
+        ></p>
+        <div class="category-meta">
+          <span class="meta-item">
+            <span class="icon-[ph--article-bold]"></span>
+            <span th:text="${category.postCount + ' 篇文章'}">0 篇文章</span>
+          </span>
+        </div>
+      </div>
+      <img
+        th:if="${not #strings.isEmpty(category.spec.cover)}"
+        th:src="${category.spec.cover}"
+        th:srcset="|${thumbnail.gen(category.spec.cover, 's')} 400w, ${thumbnail.gen(category.spec.cover, 'm')} 800w|"
+        sizes="200px"
+        class="category-cover"
+        th:alt="${category.spec.displayName}"
+      />
+    </header>
+
+    <th:block th:replace="~{modules/post-list :: list(posts=${posts}, caller='category')}" />
+  </div>
+</th:block>

--- a/templates/modules/post-list.html
+++ b/templates/modules/post-list.html
@@ -79,7 +79,10 @@
   <th:block th:if="${caller == 'category'}">
     <th:block th:replace="~{modules/pagination :: pagination(data=${posts})}" />
   </th:block>
-  <th:block th:unless="${caller == 'category'}">
+  <th:block th:if="${caller == 'tag'}">
+    <th:block th:replace="~{modules/pagination :: pagination(data=${posts})}" />
+  </th:block>
+  <th:block th:if="${caller == 'index'}">
     <th:block th:replace="~{modules/pagination :: paginationIndex(data=${posts})}" />
   </th:block>
 </div>

--- a/templates/modules/tag-layout-new.html
+++ b/templates/modules/tag-layout-new.html
@@ -1,0 +1,43 @@
+<th:block th:fragment="layout(tag, posts, thumbnail)">
+  <div class="archive proper-height">
+    <header class="tag-header">
+      <a href="/tags" class="tag-back" title="返回标签云">
+        <span class="icon-[ph--arrow-left-bold]"></span>
+        <span>标签云</span>
+      </a>
+      <div class="tag-info">
+        <h1 class="tag-name"><span class="tag-hash">#</span><span th:text="${tag.spec.displayName}"></span></h1>
+        <p class="tag-meta">共 <strong th:text="${posts.total}">0</strong> 篇文章</p>
+      </div>
+    </header>
+
+    <menu class="tag-list">
+      <li
+        th:each="post,postStat : ${posts.items}"
+        class="article-item"
+        th:style="'--delay: ' + ${postStat.index * 0.03} + 's'"
+      >
+        <time th:text="${#temporals.format(post.spec.publishTime, 'MM/dd')}"></time>
+        <a th:href="${post.status.permalink}" class="article-link gradient-card" th:title="${post.status.excerpt}">
+          <span class="article-title" th:text="${post.spec.title}"></span>
+          <img
+            th:if="${post.spec.cover}"
+            th:src="${post.spec.cover}"
+            th:srcset="|${thumbnail.gen(post.spec.cover, 's')} 400w|"
+            sizes="100px"
+            class="article-cover"
+            loading="lazy"
+            th:alt="${post.spec.title}"
+          />
+        </a>
+      </li>
+    </menu>
+
+    <div th:if="${#lists.isEmpty(posts.items)}" class="empty-state">
+      <span class="icon-[ph--article-bold]"></span>
+      <p>该标签下暂无文章</p>
+    </div>
+
+    <th:block th:replace="~{modules/pagination :: pagination(data=${posts})}" />
+  </div>
+</th:block>

--- a/templates/modules/tag-layout-old.html
+++ b/templates/modules/tag-layout-old.html
@@ -1,0 +1,28 @@
+<th:block th:fragment="layout(tag, posts, thumbnail)">
+  <div class="category-page">
+    <header class="category-header card">
+      <div class="category-info">
+        <h1 class="category-title text-creative">
+          <span class="icon-[ph--hash-bold]"></span>
+          <span th:text="${tag.spec.displayName}">标签名称</span>
+        </h1>
+        <div class="category-meta">
+          <span class="meta-item">
+            <span class="icon-[ph--article-bold]"></span>
+            <span th:text="${tag.postCount + ' 篇文章'}">0 篇文章</span>
+          </span>
+        </div>
+      </div>
+      <img
+        th:if="${not #strings.isEmpty(tag.spec.cover)}"
+        th:src="${tag.spec.cover}"
+        th:srcset="|${thumbnail.gen(tag.spec.cover, 's')} 400w, ${thumbnail.gen(tag.spec.cover, 'm')} 800w|"
+        sizes="200px"
+        class="category-cover"
+        th:alt="${tag.spec.displayName}"
+      />
+    </header>
+
+    <th:block th:replace="~{modules/post-list :: list(posts=${posts}, caller='tag')}" />
+  </div>
+</th:block>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,38 +1,14 @@
 <!doctype html>
-<html xmlns:th="https://www.thymeleaf.org" th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = ${tag.spec.displayName})}">
+<html
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = ${tag.spec.displayName})}"
+>
   <th:block th:fragment="content">
-    <div class="archive proper-height">
-      <header class="tag-header">
-        <a href="/tags" class="tag-back" title="返回标签云">
-          <span class="icon-[ph--arrow-left-bold]"></span>
-          <span>标签云</span>
-        </a>
-        <div class="tag-info">
-          <h1 class="tag-name">
-            <span class="tag-hash">#</span><span th:text="${tag.spec.displayName}"></span>
-          </h1>
-          <p class="tag-meta">
-            共 <strong th:text="${posts.total}">0</strong> 篇文章
-          </p>
-        </div>
-      </header>
-
-      <menu class="archive-list">
-        <li th:each="post,postStat : ${posts.items}" class="article-item" th:style="'--delay: ' + ${postStat.index * 0.03} + 's'">
-          <time th:text="${#temporals.format(post.spec.publishTime, 'MM/dd')}"></time>
-          <a th:href="${post.status.permalink}" class="article-link gradient-card" th:title="${post.status.excerpt}">
-            <span class="article-title" th:text="${post.spec.title}"></span>
-            <img th:if="${post.spec.cover}" th:src="${post.spec.cover}" th:srcset="|${thumbnail.gen(post.spec.cover, 's')} 400w|" sizes="100px" class="article-cover" loading="lazy" th:alt="${post.spec.title}" />
-          </a>
-        </li>
-      </menu>
-
-      <div th:if="${#lists.isEmpty(posts.items)}" class="empty-state">
-        <span class="icon-[ph--article-bold]"></span>
-        <p>该标签下暂无文章</p>
-      </div>
-
-      <th:block th:replace="~{modules/pagination :: pagination(data=${posts})}" />
-    </div>
+    <th:block th:if="${theme.config.style.switch_tag_layout == false}">
+      <th:block th:replace="~{modules/tag-layout-old :: layout(tag=${tag}, posts=${posts}, thumbnail=${thumbnail})}" />
+    </th:block>
+    <th:block th:if="${theme.config.style.switch_tag_layout == true}">
+      <th:block th:replace="~{modules/tag-layout-new :: layout(tag=${tag}, posts=${posts}, thumbnail=${thumbnail})}" />
+    </th:block>
   </th:block>
 </html>


### PR DESCRIPTION
## 功能
- 支持切换分类页与标签页的布局

## 效果
### 分类
<img width="2464" height="1289" alt="image" src="https://github.com/user-attachments/assets/01d533b1-3be6-4cc7-98fe-b42d59f87a44" />
<img width="2464" height="1289" alt="image" src="https://github.com/user-attachments/assets/f1738e42-b16b-4847-99fa-923fcf682507" />

### 标签
<img width="2464" height="1289" alt="image" src="https://github.com/user-attachments/assets/e890872d-e820-4940-89cf-b3f13c4ce7ca" />
<img width="2464" height="1289" alt="image" src="https://github.com/user-attachments/assets/6de6059c-0975-4070-bc27-d55f3133d9b9" />

