### PR TITLE
feat(theme): 添加主题默认模式设置选项

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -165,6 +165,18 @@ spec:
           label: 切换标签文章样式布局
           value: false
           help: 切换标签页面的文章列表样式布局
+        - $formkit: radio
+          name: theme_mode
+          id: theme_mode
+          label: 主题默认模式
+          value: light
+          options:
+            - value: light
+              label: 浅色模式
+            - value: dark
+              label: 深色模式
+            - value: system
+              label: 跟随系统
     - group: footer
       label: 页脚 & 社交
       formSchema:

--- a/src/alpine/themeToggle.ts
+++ b/src/alpine/themeToggle.ts
@@ -2,7 +2,7 @@ import type Alpine from "alpinejs";
 
 export function registerThemeToggle(alpine: typeof Alpine) {
   alpine.data("themeToggle", () => ({
-    theme: localStorage.getItem("theme") || "system",
+    theme: localStorage.getItem("theme") || (window as any).themeConfig?.style?.theme_mode || "system",
 
     init() {
       this.applyTheme(false);

--- a/templates/modules/layout.html
+++ b/templates/modules/layout.html
@@ -62,21 +62,25 @@
         --c-accent: [(${theme.config.style.accent_color})] !important;
       }
     </style>
-    <script>
-      (function () {
-        const theme = localStorage.getItem("theme") || "system";
-        const isDark =
-          theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
-        if (isDark) {
-          document.documentElement.classList.add("dark");
-        }
-      })();
-    </script>
     <script th:inline="javascript">
       window.themeConfig = window.themeConfig || {};
       window.themeConfig.custom = window.themeConfig.custom || {};
       window.themeConfig.custom.img_alt = /*[[${theme.config.custom.img_alt}]]*/ false;
       window.themeConfig.custom.enable_fancybox = /*[[${theme.config.custom.enable_fancybox}]]*/ true;
+      window.themeConfig.style = window.themeConfig.style || {};
+      window.themeConfig.style.theme_mode = /*[[${theme.config.style.theme_mode}]]*/ "light";
+    </script>
+    <script>
+      (function () {
+        const theme = localStorage.getItem("theme") || window.themeConfig?.style?.theme_mode || "system";
+
+        const isDark =
+          theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+        if (isDark) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
     </script>
   </head>
   <body id="clarity-root">


### PR DESCRIPTION
Fixed: #56 

## 功能
可在后台设置主题的默认模式，客户端优先级最高，测试前请删除 cookie 或在隐私窗口。

<img width="694" height="226" alt="image" src="https://github.com/user-attachments/assets/fbba2c58-da81-4dd5-99d5-870fdd8d3394" />
