### PR TITLE
feat(aside): 添加推广轮播小组件

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -478,6 +478,8 @@ spec:
                       label: 云计算支持
                     - value: "custom"
                       label: 自定义
+                    - value: "promotion"
+                      label: 推广轮播
                 - $formkit: text
                   name: moments_title
                   label: 标题
@@ -589,6 +591,55 @@ spec:
               label: 心知天气 API Key
               placeholder: 请输入心知天气 API Key
               help: "前往 https://www.seniverse.com 注册获取，免费版即可，自动根据访客 IP 定位"
+        - $formkit: group
+          name: promotion
+          label: 推广轮播配置
+          children:
+            - $formkit: text
+              name: title
+              label: 标题
+              value: "推广"
+              placeholder: 推广
+            - $formkit: number
+              name: height
+              label: 图片高度 (px)
+              value: 120
+              min: 80
+              max: 300
+              help: 轮播图片的显示高度（像素）
+            - $formkit: number
+              name: interval
+              label: 自动切换间隔 (秒)
+              value: 5
+              min: 0
+              max: 30
+              help: 设为 0 则不自动切换
+            - $formkit: array
+              name: items
+              label: 轮播项
+              value: []
+              help: 前端最多显示 6 个轮播项
+              itemLabels:
+                - type: image
+                  label: $value.image
+                - type: text
+                  label: $value.tip
+              children:
+                - $formkit: attachment
+                  name: image
+                  label: 图片
+                  accepts:
+                    - "image/*"
+                  validation: required
+                - $formkit: text
+                  name: tip
+                  label: 提示文字
+                  placeholder: 图片描述
+                - $formkit: url
+                  name: url
+                  label: 跳转链接
+                  placeholder: https://example.com
+                  help: 可选，点击图片跳转的地址
     - group: post
       label: 文章
       formSchema:

--- a/src/styles/scss/components/_aside.scss
+++ b/src/styles/scss/components/_aside.scss
@@ -602,3 +602,93 @@ a.sponsor-card.widget-card.with-bg {
 		font-size: 1.3em;
 	}
 }
+
+// ========================================
+// 推广轮播组件 (Promotion Carousel)
+// ========================================
+.promotion-carousel {
+	position: relative;
+	height: var(--promotion-height, 120px);
+	padding: 0 !important;
+	overflow: hidden;
+	border-radius: 0.8rem;
+}
+
+.promotion-track {
+	position: relative;
+	width: 100%;
+	height: var(--promotion-height, 120px);
+}
+
+.promotion-slide {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: flex-end;
+	opacity: 0;
+	transition: opacity 0.4s ease-in-out;
+	text-decoration: none;
+	color: inherit;
+
+	&.active {
+		opacity: 1;
+		z-index: 1;
+	}
+
+	img {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+}
+
+.promotion-tip {
+	position: relative;
+	z-index: 2;
+	display: block;
+	width: 100%;
+	// 右边距动态计算：每个圆点 6px + 活跃态额外 10px + 间距(count-1)*5px + 安全边距 12px
+	padding: 1.5em 0.6em 0.4em;
+	padding-right: calc((var(--promotion-count, 1) * 11px) + 12px);
+	font-size: 0.8em;
+	line-height: 1.4;
+	color: #fff;
+	background: linear-gradient(to top, rgba(0, 0, 0, 0.6) 0%, transparent 100%);
+	border-radius: 0 0 0.8rem 0.8rem;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.promotion-dots {
+	position: absolute;
+	bottom: 0.4em;
+	right: 0.5em;
+	display: flex;
+	gap: 0.35em;
+	z-index: 10;
+}
+
+.promotion-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 3px;
+	background-color: rgba(255, 255, 255, 0.6);
+	// 轻柔的描边 + 投影，确保在浅色背景上可见
+	box-shadow:
+		inset 0 0 0 1px rgba(0, 0, 0, 0.1),
+		0 1px 2px rgba(0, 0, 0, 0.15);
+	cursor: pointer;
+	transition: all 0.25s ease;
+
+	&:hover {
+		background-color: rgba(255, 255, 255, 0.9);
+	}
+
+	&.active {
+		width: 16px;
+		background-color: #fff;
+	}
+}

--- a/templates/modules/aside.html
+++ b/templates/modules/aside.html
@@ -531,6 +531,107 @@
           </a>
         </section>
 
+        <section
+          th:case="'promotion'"
+          class="widget"
+          th:if="${theme.config.aside.promotion?.items != null and not #lists.isEmpty(theme.config.aside.promotion.items)}"
+          th:with="totalCount = ${#lists.size(theme.config.aside.promotion.items)}, itemCount = ${T(java.lang.Math).min(totalCount, 6)}"
+        >
+          <hgroup class="widget-title text-creative" th:text="${theme.config.aside.promotion?.title} ?: '推广'">
+            推广
+          </hgroup>
+          <div
+            class="widget-body widget-card promotion-carousel"
+            th:style="|--promotion-height: ${theme.config.aside.promotion?.height ?: 120}px; --promotion-count: ${itemCount}|"
+            th:data-interval="${theme.config.aside.promotion?.interval ?: 5}"
+          >
+            <div class="promotion-track">
+              <th:block th:each="slide, iterStat : ${theme.config.aside.promotion.items}" th:if="${iterStat.index < 6}">
+                <a
+                  th:if="${not #strings.isEmpty(slide.url)}"
+                  th:href="${slide.url}"
+                  target="_blank"
+                  rel="noopener noreferrer sponsored"
+                  class="promotion-slide"
+                  th:classappend="${iterStat.first} ? 'active' : ''"
+                >
+                  <img th:src="${slide.image}" th:alt="${slide.tip}" loading="lazy" />
+                  <span th:if="${not #strings.isEmpty(slide.tip)}" class="promotion-tip" th:text="${slide.tip}"></span>
+                </a>
+                <div
+                  th:unless="${not #strings.isEmpty(slide.url)}"
+                  class="promotion-slide"
+                  th:classappend="${iterStat.first} ? 'active' : ''"
+                >
+                  <img th:src="${slide.image}" th:alt="${slide.tip}" loading="lazy" />
+                  <span th:if="${not #strings.isEmpty(slide.tip)}" class="promotion-tip" th:text="${slide.tip}"></span>
+                </div>
+              </th:block>
+            </div>
+            <div class="promotion-dots" th:if="${itemCount > 1}">
+              <span
+                th:each="slide, iterStat : ${theme.config.aside.promotion.items}"
+                th:if="${iterStat.index < 6}"
+                class="promotion-dot"
+                th:classappend="${iterStat.first} ? 'active' : ''"
+                th:data-index="${iterStat.index}"
+              ></span>
+            </div>
+          </div>
+          <script>
+            (function () {
+              const carousel = document.querySelector(".promotion-carousel");
+              if (!carousel) return;
+
+              const slides = carousel.querySelectorAll(".promotion-slide");
+              const dots = carousel.querySelectorAll(".promotion-dot");
+              if (slides.length <= 1) return;
+
+              const interval = parseInt(carousel.dataset.interval) || 5;
+              let current = 0;
+              let timer = null;
+
+              function showSlide(index) {
+                slides.forEach((s, i) => s.classList.toggle("active", i === index));
+                dots.forEach((d, i) => d.classList.toggle("active", i === index));
+                current = index;
+              }
+
+              function next() {
+                showSlide((current + 1) % slides.length);
+              }
+
+              function startAuto() {
+                if (interval > 0 && !timer) {
+                  timer = setInterval(next, interval * 1000);
+                }
+              }
+
+              function stopAuto() {
+                if (timer) {
+                  clearInterval(timer);
+                  timer = null;
+                }
+              }
+
+              // 圆点点击
+              dots.forEach((dot) => {
+                dot.addEventListener("click", () => {
+                  showSlide(parseInt(dot.dataset.index));
+                  stopAuto();
+                  startAuto();
+                });
+              });
+
+              // 鼠标悬停暂停
+              carousel.addEventListener("mouseenter", stopAuto);
+              carousel.addEventListener("mouseleave", startAuto);
+
+              startAuto();
+            })();
+          </script>
+        </section>
+
         <section th:case="'custom'" class="widget">
           <hgroup class="widget-title text-creative" th:text="${item.title}">自定义</hgroup>
           <div class="widget-body widget-card" th:utext="${item.content}"></div>


### PR DESCRIPTION
在右侧边栏新增推广轮播组件，支持：
- 可配置标题、图片高度、自动切换间隔
- 最多 6 个轮播项，每项可设置图片、提示文字和跳转链接
- 淡入淡出切换动画，鼠标悬停暂停
- 指示器点击切换，带轻柔阴影确保在浅色背景上可见