### PR TITLE
fix(homepage-widgets): 添加空值检查防止获取空文章名时出错

### DIFF
--- a/templates/modules/homepage-widgets.html
+++ b/templates/modules/homepage-widgets.html
@@ -23,7 +23,10 @@
           <div class="z-slide-body">
             <div class="slide-list" th:id="|slide-scroll-container-${itemStat.index}|">
               <th:block th:each="postName : ${theme.config.post.featured.posts}">
-                <th:block th:with="post = ${postFinder.getByName(postName)}">
+                <th:block
+                  th:if="${postName != null and postName != ''}"
+                  th:with="post = ${postFinder.getByName(postName)}"
+                >
                   <a
                     th:if="${post != null}"
                     th:href="${post.status.permalink}"


### PR DESCRIPTION
## 问题

```
2026-02-06T13:25:05.448+08:00 ERROR 7 --- [reactor-http-epoll-1] o.s.w.s.adapter.HttpWebHandlerAdapter    : [f574a183-14957] Error [org.thymeleaf.exceptions.TemplateProcessingException: Exception evaluating SpringEL expression: "postFinder.getByName(postName)" (template: "modules/homepage-widgets" - line 26, col 27)] for HTTP GET "/", but ServerHttpResponse already committed (200 OK)
2026-02-06T13:25:05.449+08:00 ERROR 7 --- [reactor-http-epoll-1] r.n.http.server.HttpServerOperations     : [f574a183-1, L:/172.18.0.5:8090 - R:/172.18.0.1:39222] Error finishing response. Closing connection

org.thymeleaf.exceptions.TemplateProcessingException: Exception evaluating SpringEL expression: "postFinder.getByName(postName)" (template: "modules/homepage-widgets" - line 26, col 27)
	at org.thymeleaf.spring6.expression.SPELVariableExpressionEvaluator.evaluate(SPELVariableExpressionEvaluator.java:292) ~[thymeleaf-spring6-3.1.3.RELEASE.jar:3.1.3.RELEASE]
	Suppressed: The stacktrace has been enhanced by Reactor, refer to additional information below: 
Error has been observed at the following site(s):
```