### PR TITLE
pref(aside-widgets): 移除首页侧边栏中的社区组件默认配置

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -458,7 +458,6 @@ spec:
               value:
                 - widget: "stats"
                 - widget: "tech-info"
-                - widget: "community"
               children:
                 - $formkit: select
                   name: widget


### PR DESCRIPTION
- 由于社区组件默认未配置完成，用户首次使用时不会加载右侧边栏。