### PR TITLE
fix(hot-post-widget): 修复热门文章数量类型转换问题

### DIFF
--- a/templates/modules/home-widgets/hot-post-widget.html
+++ b/templates/modules/home-widgets/hot-post-widget.html
@@ -1,7 +1,7 @@
 <div
   class="z-slide"
   th:fragment="hot-post"
-  th:if="${theme.config.post.hot_post != null and theme.config.post.hot_post.post_number > 0}"
+  th:if="${theme.config.post.hot_post != null and T(java.lang.Integer).parseInt(theme.config.post.hot_post.post_number) > 0}"
 >
   <div
     th:replace="~{modules/home-widgets/slide-widget-base::header(${theme.config.post.hot_post.title ?: '热门文章'})}"
@@ -10,11 +10,12 @@
   <div class="z-slide-body">
     <div class="slide-list" id="hot-post-scroll-container">
       <th:block
-        th:with="posts = ${postFinder.list({
-        page: 1,
-        size: theme.config.post.hot_post.post_number,
-        sort: {'stats.visit,desc', 'metadata.creationTimestamp,asc'}
-      })}"
+        th:with="postNumber = ${T(java.lang.Integer).parseInt(theme.config.post.hot_post.post_number)},
+                 posts = ${postFinder.list({
+                   page: 1,
+                   size: postNumber,
+                   sort: {'stats.visit,desc', 'metadata.creationTimestamp,asc'}
+                 })}"
       >
         <th:block th:each="post : ${posts.items}">
           <div th:replace="~{modules/home-widgets/slide-widget-base::post-item(${post})}"></div>


### PR DESCRIPTION
## log

```
2026-02-09T14:45:06.350+08:00 ERROR 7 --- [reactor-http-epoll-3] o.s.w.s.adapter.HttpWebHandlerAdapter    : [50b91700-7398] Error [org.thymeleaf.exceptions.TemplateProcessingException: Exception evaluating SpringEL expression: "theme.config.post.hot_post != null and #strings.length(theme.config.post.hot_post.post_number) > 0 and #numbers.integer(theme.config.post.hot_post.post_number) > 0" (template: "modules/home-widgets/hot-post-widget" - line 4, col 3)] for HTTP GET "/", but ServerHttpResponse already committed (200 OK)
2026-02-09T14:45:06.350+08:00 ERROR 7 --- [reactor-http-epoll-3] r.n.http.server.HttpServerOperations     : [50b91700-1, L:/172.18.0.5:8090 - R:/172.18.0.1:44218] Error finishing response. Closing connection

org.thymeleaf.exceptions.TemplateProcessingException: Exception evaluating SpringEL expression: "theme.config.post.hot_post != null and #strings.length(theme.config.post.hot_post.post_number) > 0 and #numbers.integer(theme.config.post.hot_post.post_number) > 0" (template: "modules/home-widgets/hot-post-widget" - line 4, col 3)
	at org.thymeleaf.spring6.expression.SPELVariableExpressionEvaluator.evaluate(SPELVariableExpressionEvaluator.java:292) ~[thymeleaf-spring6-3.1.3.RELEASE.jar:3.1.3.RELEASE]
	Suppressed: The stacktrace has been enhanced by Reactor, refer to additional information below: 
Error has been observed at the following site(s):
	*__checkpoint ⇢ Handler run.halo.app.theme.router.factories.IndexRouteFactory$$Lambda/0x00000000b806d980@f9ee65ba [DispatcherHandler]
	*__checkpoint ⇢ run.halo.app.security.InitializeRedirectionWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.cache.page.PageCacheWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ SwitchUserWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ AuthorizationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ ExceptionTranslationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ LogoutWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ ServerRequestCacheWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityContextServerWebExchangeWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ AnonymousAuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ top.ilay.authpasskey.PasskeyAuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.oauth.HaloOAuth2AuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.social.login.security.SocialAuthenticatorFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ AuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ AuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ AuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ MapOAuth2AuthenticationFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ AuthenticationWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢  [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.oauth.HaloOAuth2RedirectWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.social.login.security.SocialAuthorizationRequestRedirectWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ CaptchaWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ DeviceSessionFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ ReactorContextWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ CsrfWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ CorsWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ HttpHeaderWriterWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ SecurityWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ ServerWebExchangeReactorContextWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ org.springframework.security.web.server.WebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.seo.tools.AdvancedRedirectWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.moments.rss.OldRssRouteRedirectionFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ site.muyin.linkssubmit.filter.LinksSubmitApiWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.comment.widget.captcha.CommentCaptchaFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.seo.tools.CrawlRecordFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.router.TrailingSlashRedirectFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ cc.ryanc.staticpages.endpoint.RewriteOnNotFoundFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ com.timxs.storagetoolkit.filter.ImageProcessingWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.app.infra.webfilter.AdditionalWebFilterChainProxy [DefaultWebFilterChain]
	*__checkpoint ⇢ org.springframework.web.filter.reactive.ServerWebExchangeContextFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.app.infra.webfilter.LocaleChangeWebFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ org.springframework.web.filter.reactive.UrlHandlerFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ run.halo.app.theme.UserLocaleRequestAttributeWriteFilter [DefaultWebFilterChain]
	*__checkpoint ⇢ HTTP GET "/" [ExceptionHandlingWebHandler]
Original Stack Trace:
		at org.thymeleaf.spring6.expression.SPELVariableExpressionEvaluator.evaluate(SPELVariableExpressionEvaluator.java:292) ~[thymeleaf-spring6-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at run.halo.app.theme.ReactiveSpelVariableExpressionEvaluator.evaluate(ReactiveSpelVariableExpressionEvaluator.java:39) ~[classes/:2.22.14]
		at org.thymeleaf.standard.expression.VariableExpression.executeVariableExpression(VariableExpression.java:166) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.standard.expression.SimpleExpression.executeSimple(SimpleExpression.java:66) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.standard.expression.Expression.execute(Expression.java:109) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.standard.expression.Expression.execute(Expression.java:138) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.standard.expression.Expression.execute(Expression.java:125) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.standard.processor.StandardIfTagProcessor.isVisible(StandardIfTagProcessor.java:59) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.standard.processor.AbstractStandardConditionalVisibilityTagProcessor.doProcess(AbstractStandardConditionalVisibilityTagProcessor.java:61) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.processor.element.AbstractAttributeTagProcessor.doProcess(AbstractAttributeTagProcessor.java:74) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.processor.element.AbstractElementTagProcessor.process(AbstractElementTagProcessor.java:95) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.util.ProcessorConfigurationUtils$ElementTagProcessorWrapper.process(ProcessorConfigurationUtils.java:633) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ProcessorTemplateHandler.handleOpenElement(ProcessorTemplateHandler.java:1314) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.OpenElementTag.beHandled(OpenElementTag.java:205) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.Model.process(Model.java:300) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.OpenElementTagModelProcessable.process(OpenElementTagModelProcessable.java:110) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ProcessorTemplateHandler.queueProcessable(ProcessorTemplateHandler.java:2106) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ProcessorTemplateHandler.handleOpenElement(ProcessorTemplateHandler.java:1559) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.OpenElementTag.beHandled(OpenElementTag.java:205) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.Model.process(Model.java:300) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.IteratedGatheringModelProcessable.processIterationModel(IteratedGatheringModelProcessable.java:368) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.IteratedGatheringModelProcessable.process(IteratedGatheringModelProcessable.java:222) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ProcessorTemplateHandler.queueProcessable(ProcessorTemplateHandler.java:2106) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ProcessorTemplateHandler.handleCloseElement(ProcessorTemplateHandler.java:1642) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.CloseElementTag.beHandled(CloseElementTag.java:139) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.Model.process(Model.java:300) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.StandaloneElementTagModelProcessable.process(StandaloneElementTagModelProcessable.java:114) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ProcessorTemplateHandler.queueProcessable(ProcessorTemplateHandler.java:2106) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ProcessorTemplateHandler.handleStandaloneElement(ProcessorTemplateHandler.java:1179) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.StandaloneElementTag.beHandled(StandaloneElementTag.java:228) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.Model.process(Model.java:300) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.StandaloneElementTagModelProcessable.process(StandaloneElementTagModelProcessable.java:114) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ProcessorTemplateHandler.queueProcessable(ProcessorTemplateHandler.java:2106) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ProcessorTemplateHandler.handleStandaloneElement(ProcessorTemplateHandler.java:1179) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.StandaloneElementTag.beHandled(StandaloneElementTag.java:228) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.Model.process(Model.java:300) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.OpenElementTagModelProcessable.process(OpenElementTagModelProcessable.java:110) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ProcessorTemplateHandler.handlePending(ProcessorTemplateHandler.java:2054) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ThrottledTemplateProcessor.process(ThrottledTemplateProcessor.java:234) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.engine.ThrottledTemplateProcessor.process(ThrottledTemplateProcessor.java:204) ~[thymeleaf-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.spring6.SpringWebFluxTemplateEngine$StreamThrottledTemplateProcessor.process(SpringWebFluxTemplateEngine.java:739) ~[thymeleaf-spring6-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at org.thymeleaf.spring6.SpringWebFluxTemplateEngine.lambda$createChunkedStream$2(SpringWebFluxTemplateEngine.java:269) ~[thymeleaf-spring6-3.1.3.RELEASE.jar:3.1.3.RELEASE]
		at reactor.core.publisher.FluxGenerate$GenerateSubscription.slowPath(FluxGenerate.java:271) ~[reactor-core-3.7.14.jar:3.7.14]
		at reactor.core.publisher.FluxGenerate$GenerateSubscription.request(FluxGenerate.java:213) ~[reactor-core-3.7.14.jar:3.7.14]
		at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.request(FluxContextWrite.java:136) ~[reactor-core-3.7.14.jar:3.7.14]
		at reactor.core.publisher.FluxPeekFuseable$PeekFuseableSubscriber.request(FluxPeekFuseable.java:144) ~[reactor-core-3.7.14.jar:3.7.14]
		at reactor.core.publisher.FluxSubscribeOn$SubscribeOnSubscriber.lambda$requestUpstream$0(FluxSubscribeOn.java:135) ~[reactor-core-3.7.14.jar:3.7.14]
		at reactor.core.scheduler.BoundedElasticThreadPerTaskScheduler$SchedulerTask.run(BoundedElasticThreadPerTaskScheduler.java:1013) ~[reactor-core-3.7.14.jar:3.7.14]
		at java.base/java.lang.VirtualThread.run(Unknown Source) ~[na:na]
Caused by: org.springframework.expression.spel.SpelEvaluationException: EL1004E: Method call: Method integer(java.lang.String) cannot be found on type org.thymeleaf.expression.Numbers
```