### PR TITLE
feat(aside): 推广轮播组件动画修改，并支持拖拽手势和显示数量配置

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -613,11 +613,18 @@ spec:
               min: 0
               max: 30
               help: 设为 0 则不自动切换
+            - $formkit: number
+              name: display_count
+              label: 显示数量
+              value: 6
+              min: 1
+              max: 20
+              help: 前端最多显示的轮播项数量，超出部分不会渲染
             - $formkit: array
               name: items
               label: 轮播项
               value: []
-              help: 前端最多显示 6 个轮播项
+              help: 显示数量由「显示数量」配置项控制
               itemLabels:
                 - type: image
                   label: $value.image

--- a/src/styles/scss/components/_aside.scss
+++ b/src/styles/scss/components/_aside.scss
@@ -612,28 +612,33 @@ a.sponsor-card.widget-card.with-bg {
 	padding: 0 !important;
 	overflow: hidden;
 	border-radius: 0.8rem;
+	cursor: grab;
+	touch-action: pan-y pinch-zoom;
+	user-select: none;
+
+	&.dragging {
+		cursor: grabbing;
+	}
+
+	&.single {
+		cursor: default;
+	}
 }
 
 .promotion-track {
-	position: relative;
+	display: flex;
 	width: 100%;
 	height: var(--promotion-height, 120px);
+	will-change: transform;
 }
 
 .promotion-slide {
-	position: absolute;
-	inset: 0;
+	flex: 0 0 100%;
+	position: relative;
 	display: flex;
 	align-items: flex-end;
-	opacity: 0;
-	transition: opacity 0.4s ease-in-out;
 	text-decoration: none;
 	color: inherit;
-
-	&.active {
-		opacity: 1;
-		z-index: 1;
-	}
 
 	img {
 		position: absolute;
@@ -641,6 +646,7 @@ a.sponsor-card.widget-card.with-bg {
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
+		pointer-events: none;
 	}
 }
 

--- a/templates/modules/aside-widgets/promotion-widget.html
+++ b/templates/modules/aside-widgets/promotion-widget.html
@@ -2,33 +2,29 @@
   th:fragment="promotion-widget"
   class="widget"
   th:if="${theme.config.aside.promotion?.items != null and not #lists.isEmpty(theme.config.aside.promotion.items)}"
-  th:with="totalCount = ${#lists.size(theme.config.aside.promotion.items)}, itemCount = ${T(java.lang.Math).min(totalCount, 6)}"
+  th:with="totalCount = ${#lists.size(theme.config.aside.promotion.items)}, displayCount = ${T(java.lang.Integer).parseInt(theme.config.aside.promotion?.display_count ?: '6')}, itemCount = ${T(java.lang.Math).min(totalCount, displayCount)}"
 >
   <hgroup class="widget-title text-creative" th:text="${theme.config.aside.promotion?.title} ?: '推广'">推广</hgroup>
   <div
     class="widget-body widget-card promotion-carousel"
+    th:classappend="${itemCount <= 1} ? 'single' : ''"
     th:style="|--promotion-height: ${theme.config.aside.promotion?.height ?: 120}px; --promotion-count: ${itemCount}|"
     th:data-interval="${theme.config.aside.promotion?.interval ?: 5}"
   >
     <div class="promotion-track">
-      <th:block th:each="slide, iterStat : ${theme.config.aside.promotion.items}" th:if="${iterStat.index < 6}">
+      <th:block th:each="slide, iterStat : ${theme.config.aside.promotion.items}" th:if="${iterStat.index < itemCount}">
         <a
           th:if="${not #strings.isEmpty(slide.url)}"
           th:href="${slide.url}"
           target="_blank"
           rel="noopener noreferrer sponsored"
           class="promotion-slide"
-          th:classappend="${iterStat.first} ? 'active' : ''"
         >
-          <img th:src="${slide.image}" th:alt="${slide.tip}" loading="lazy" />
+          <img th:src="${slide.image}" th:alt="${slide.tip}" loading="lazy" draggable="false" />
           <span th:if="${not #strings.isEmpty(slide.tip)}" class="promotion-tip" th:text="${slide.tip}"></span>
         </a>
-        <div
-          th:unless="${not #strings.isEmpty(slide.url)}"
-          class="promotion-slide"
-          th:classappend="${iterStat.first} ? 'active' : ''"
-        >
-          <img th:src="${slide.image}" th:alt="${slide.tip}" loading="lazy" />
+        <div th:unless="${not #strings.isEmpty(slide.url)}" class="promotion-slide">
+          <img th:src="${slide.image}" th:alt="${slide.tip}" loading="lazy" draggable="false" />
           <span th:if="${not #strings.isEmpty(slide.tip)}" class="promotion-tip" th:text="${slide.tip}"></span>
         </div>
       </th:block>
@@ -36,7 +32,7 @@
     <div class="promotion-dots" th:if="${itemCount > 1}">
       <span
         th:each="slide, iterStat : ${theme.config.aside.promotion.items}"
-        th:if="${iterStat.index < 6}"
+        th:if="${iterStat.index < itemCount}"
         class="promotion-dot"
         th:classappend="${iterStat.first} ? 'active' : ''"
         th:data-index="${iterStat.index}"
@@ -48,22 +44,45 @@
       const carousel = document.querySelector(".promotion-carousel");
       if (!carousel) return;
 
-      const slides = carousel.querySelectorAll(".promotion-slide");
+      const track = carousel.querySelector(".promotion-track");
       const dots = carousel.querySelectorAll(".promotion-dot");
-      if (slides.length <= 1) return;
+      const count = carousel.querySelectorAll(".promotion-slide").length;
+      if (count <= 1) return;
 
       const interval = parseInt(carousel.dataset.interval) || 5;
       let current = 0;
       let timer = null;
 
-      function showSlide(index) {
-        slides.forEach((s, i) => s.classList.toggle("active", i === index));
-        dots.forEach((d, i) => d.classList.toggle("active", i === index));
+      // 每次使用时实时获取宽度，避免初始不可见时为 0
+      function getWidth() {
+        return carousel.offsetWidth;
+      }
+
+      // 拖拽状态
+      let isDragging = false;
+      let allowClick = true;
+      let startX = 0;
+      let startY = 0;
+      let direction = null; // "h" 水平 | "v" 垂直 | null 未定
+      let currentTranslate = 0;
+      let dragOffset = 0;
+
+      // 动画参数
+      const TRANSITION = "transform 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94)";
+      const DRAG_THRESHOLD = 0.2;
+      const DAMPING = 0.3;
+
+      function goToSlide(index, animate) {
+        const w = getWidth();
         current = index;
+        currentTranslate = -current * w;
+        track.style.transition = animate ? TRANSITION : "none";
+        track.style.transform = `translateX(${currentTranslate}px)`;
+        dots.forEach((d, i) => d.classList.toggle("active", i === index));
       }
 
       function next() {
-        showSlide((current + 1) % slides.length);
+        goToSlide((current + 1) % count, true);
       }
 
       function startAuto() {
@@ -79,10 +98,125 @@
         }
       }
 
+      function getPointer(e) {
+        const t = e.touches ? e.touches[0] : e;
+        return { x: t.clientX, y: t.clientY };
+      }
+
+      function dragStart(e) {
+        if (e.button && e.button !== 0) return;
+
+        // 仅对 mouse 事件阻止原生拖拽（Swiper 对 touchstart 直接 return，不 preventDefault）
+        // touchstart 上 preventDefault 会阻止浏览器合成 click，导致链接点不了
+        if (!e.touches && e.cancelable) e.preventDefault();
+
+        const p = getPointer(e);
+        isDragging = true;
+        allowClick = true;
+        startX = p.x;
+        startY = p.y;
+        direction = null;
+        dragOffset = 0;
+
+        track.style.transition = "none";
+        carousel.classList.add("dragging");
+        stopAuto();
+      }
+
+      function dragMove(e) {
+        if (!isDragging) return;
+
+        const p = getPointer(e);
+        const dx = p.x - startX;
+        const dy = p.y - startY;
+
+        // 方向锁定：移动距离² > 25 时判断方向（与 Swiper touchAngle 逻辑一致）
+        if (!direction) {
+          if (dx * dx + dy * dy < 25) return;
+          direction = Math.abs(dx) >= Math.abs(dy) ? "h" : "v";
+        }
+
+        // 垂直滑动：放弃拖拽，交给浏览器处理滚动
+        if (direction === "v") {
+          isDragging = false;
+          carousel.classList.remove("dragging");
+          startAuto();
+          return;
+        }
+
+        // 水平拖拽：标记不允许点击，阻止默认行为
+        allowClick = false;
+        if (e.cancelable) e.preventDefault();
+
+        // 边界阻尼
+        const w = getWidth();
+        const target = currentTranslate + dx;
+        if (target > 0) {
+          dragOffset = dx * DAMPING;
+        } else if (target < -(count - 1) * w) {
+          const overflow = target + (count - 1) * w;
+          dragOffset = dx - overflow + overflow * DAMPING;
+        } else {
+          dragOffset = dx;
+        }
+
+        // 直接更新 transform（Swiper 同样在 onTouchMove 中直接 setTranslate）
+        track.style.transform = `translateX(${currentTranslate + dragOffset}px)`;
+      }
+
+      function dragEnd() {
+        if (!isDragging) return;
+        isDragging = false;
+
+        carousel.classList.remove("dragging");
+
+        const moved = dragOffset;
+        const w = getWidth();
+        dragOffset = 0;
+
+        if (Math.abs(moved) > w * DRAG_THRESHOLD) {
+          if (moved < 0 && current < count - 1) {
+            goToSlide(current + 1, true);
+          } else if (moved > 0 && current > 0) {
+            goToSlide(current - 1, true);
+          } else {
+            goToSlide(current, true);
+          }
+        } else {
+          goToSlide(current, true);
+        }
+
+        startAuto();
+      }
+
+      // Swiper 模式：click 捕获阶段检查 allowClick 标志
+      function onClick(e) {
+        if (!allowClick) {
+          if (e.cancelable) e.preventDefault();
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+          return false;
+        }
+      }
+
+      // mouse 事件
+      carousel.addEventListener("mousedown", dragStart);
+      document.addEventListener("mousemove", dragMove);
+      document.addEventListener("mouseup", dragEnd);
+
+      // touch 事件（touchstart 无需 preventDefault，可 passive）
+      carousel.addEventListener("touchstart", dragStart, { passive: true });
+      carousel.addEventListener("touchmove", dragMove, { passive: false });
+      carousel.addEventListener("touchend", dragEnd);
+
+      // 点击拦截（捕获阶段）
+      carousel.addEventListener("click", onClick, true);
+
       // 圆点点击
       dots.forEach((dot) => {
-        dot.addEventListener("click", () => {
-          showSlide(parseInt(dot.dataset.index));
+        dot.addEventListener("click", (e) => {
+          e.stopPropagation();
+          goToSlide(parseInt(dot.dataset.index), true);
           stopAuto();
           startAuto();
         });
@@ -90,8 +224,15 @@
 
       // 鼠标悬停暂停
       carousel.addEventListener("mouseenter", stopAuto);
-      carousel.addEventListener("mouseleave", startAuto);
+      carousel.addEventListener("mouseleave", () => {
+        if (!isDragging) startAuto();
+      });
 
+      // resize 重新定位
+      window.addEventListener("resize", () => goToSlide(current, false));
+
+      // 初始定位
+      goToSlide(0, false);
       startAuto();
     })();
   </script>


### PR DESCRIPTION
- 样式改造：从 opacity fade 改为 transform slide 布局，新增拖拽光标反馈和触摸手势支持
- 新增 display_count 配置项（1-20，默认 6），前端可控制显示的轮播项数量
- 拖拽手势：统一处理 mouse/touch 事件，支持方向锁定和边界阻尼效果
- 点击防误触：参考 Swiper 源码，用 allowClick 标志位 + 捕获阶段拦截防止拖拽后误触发链接
- 单张优化：只有 1 张轮播时禁用拖拽和圆点，禁用自动播放

修改文件：
- settings.yaml: 新增 display_count 配置项
- src/styles/scss/components/_aside.scss: 样式从 fade 改为 slide 布局
- templates/modules/aside-widgets/promotion-widget.html: 模板调整 + JS 完全重写
