### PR TITLE
feat(caption_blacklist): 实现 alt 文本屏蔽列表

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -203,16 +203,6 @@ spec:
               label: 深色模式
             - value: system
               label: 跟随系统
-        - $formkit: array
-          name: caption_blacklist
-          label: 图片标题自动添加屏蔽列表
-          value: []
-          help: "添加需要屏蔽的图片标签类名，使主题在给图片添加 figcaption 时自动排除这些图片，避免与某些插件或表情包的样式冲突。"
-          children:
-            - $formkit: text
-              name: class_name
-              label: 需要屏蔽的图片标签类名
-              validation: required
 
     - group: footer
       label: 页脚 & 社交
@@ -1095,16 +1085,36 @@ spec:
               label: 横线（页面 - 网站）
         - $formkit: switch
           name: img_alt
+          id: img_alt
+          key: img_alt
           label: 启用图片 alt 文本
           value: true
           help: 开启后图片将显示 alt 文本
+        - $formkit: array
+          if: "$get(img_alt).value === true"
+          name: caption_blacklist
+          id: caption_blacklist
+          key: caption_blacklist
+          label: alt 文本屏蔽列表
+          value: []
+          help: "添加需要屏蔽的图片 alt 文本类名，使主题在给图片添加 alt 文本时自动跳过此类名下的图片。"
+          children:
+            - $formkit: text
+              name: class_name
+              label: 需要屏蔽的图片 alt 文本类名
+              placeholder: class_name
+              validation: required
         - $formkit: switch
           name: enable_post_toc
+          id: enable_post_toc
+          key: enable_post_toc
           label: 启用文章目录
           value: true
           help: 开启后文章页面将显示目录
         - $formkit: switch
           name: enable_page_toc
+          id: enable_page_toc
+          key: enable_page_toc
           label: 启用独立页面目录
           value: false
           help: 开启后需要在页面设置中启用目录功能独立页面才会显示目录
@@ -1112,6 +1122,8 @@ spec:
           onValue: true
           offValue: false
           name: enable_edit
+          id: enable_edit
+          key: enable_edit
           label: 启用编辑按钮
           value: false
           help: 开启后文章/页面将显示编辑按钮
@@ -1119,12 +1131,15 @@ spec:
           onValue: true
           offValue: false
           name: enable_page_jump
+          id: enable_page_jump
+          key: enable_page_jump
           label: 启用分页跳转
           value: false
           help: 开启后分页将显示跳转功能
         - $formkit: number
           name: page_side_count
           id: page_side_count
+          key: page_side_count
           label: 当前页两边显示数量（不包含首尾）
           value: 2
           min: 2
@@ -1133,12 +1148,15 @@ spec:
         - $formkit: switch
           name: archives_years
           id: archives_years
+          key: archives_years
           label: 切换年龄来源
           value: true
           help: 开启后，年龄来源为建站时间，关闭后，年龄来源为网站拥有者的生日
         - $formkit: date
           if: "$get(archives_years).value === false"
           name: owner_birthday
+          id: owner_birthday
+          key: owner_birthday
           label: 你的生日
           value: "2001-01-01"
           help: 用于计算你的年龄
@@ -1146,6 +1164,8 @@ spec:
           onValue: true
           offValue: false
           name: enable_fancybox
+          id: enable_fancybox
+          key: enable_fancybox
           label: 关闭 FancyBox
           value: false
           help: 如果使用了其它灯箱插件，可以关闭 FancyBox 灯箱，避免重复加载
@@ -1153,11 +1173,15 @@ spec:
           onValue: true
           offValue: false
           name: enable_pjax
+          id: enable_pjax
+          key: enable_pjax
           label: 启用 PJAX
           value: false
           help: 开启后页面切换将使用 PJAX 技术，提升用户体验。注意：某些插件可能不兼容 PJAX ，使用 PJAX 需要舍弃一些功能。
         - $formkit: array
           name: preconnect_urls
+          id: preconnect_urls
+          key: preconnect_urls
           label: 预连接域名
           value: []
           help: "添加第三方服务域名以提前建立连接，提升加载速度（如统计服务、CDN 等）"

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -16,10 +16,10 @@ declare global {
         img_alt?: boolean;
         enable_fancybox?: boolean;
         enable_pjax?: boolean;
+        caption_blacklist?: Array<{ class_name?: string; realNode?: { class_name?: string } }>;
       };
       style?: {
         theme_mode?: "light" | "dark" | "system";
-        caption_blacklist?: Array<{ realNode: { class_name: string } }>;
       };
     };
     reinitializeComponents?: () => void;

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -24,9 +24,10 @@ export const initImageCaption = () => {
 
     if (img.closest(".c-pic, [data-type='gallery']")) return;
 
-    const blacklist = window.themeConfig?.style?.caption_blacklist || [];
+    const blacklist = window.themeConfig?.custom?.caption_blacklist || [];
     const isBlacklisted = blacklist.some((item) => {
-      img.classList.contains(item?.realNode?.class_name);
+      const className = item?.class_name || item?.realNode?.class_name;
+      return className && img.classList.contains(className);
     });
     if (isBlacklisted) return;
 

--- a/templates/modules/layout.html
+++ b/templates/modules/layout.html
@@ -78,9 +78,9 @@
       window.themeConfig.custom.enable_fancybox = /*[[${theme.config.custom.enable_fancybox}]]*/ true;
       window.themeConfig.custom.enable_pjax = /*[[${theme.config.custom.enable_pjax}]]*/ false;
       window.themeConfig.custom.enable_page_jump = /*[[${theme.config.custom.enable_page_jump}]]*/ false;
+      window.themeConfig.custom.caption_blacklist = /*[[${theme.config.custom.caption_blacklist}]]*/ [];
       window.themeConfig.style = window.themeConfig.style || {};
       window.themeConfig.style.theme_mode = /*[[${theme.config.style.theme_mode}]]*/ "light";
-      window.themeConfig.style.caption_blacklist = /*[[${theme.config.style.caption_blacklist}]]*/ [];
     </script>
     <script>
       (function () {


### PR DESCRIPTION
### 说明

本次更新是破坏性更新，需要重新设置屏蔽列表。

<img width="2482" height="1289" alt="image" src="https://github.com/user-attachments/assets/000df8fb-e7f3-4f14-b6d7-7305bb864aeb" />
