### PR TITLE
feat: 朋友圈页面新增列表模板样式

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1191,6 +1191,42 @@ spec:
               label: 页面描述
               value: 记录生活中的美好瞬间
               placeholder: 记录生活中的美好瞬间
+        - $formkit: group
+          name: friends
+          label: 朋友圈
+          help: RSS 订阅聚合
+          children:
+            - $formkit: select
+              name: template
+              id: friends_template
+              key: friends_template
+              label: 模板样式
+              value: card
+              help: 选择朋友圈页面的展示模板
+              options:
+                - value: card
+                  label: 卡片模式（默认）
+                - value: list
+                  label: 列表模式
+            - $formkit: text
+              name: title
+              label: 页面标题
+              value: 朋友圈
+              placeholder: 朋友圈
+            - $formkit: text
+              if: "$get(friends_template).value === 'list'"
+              name: banner_desc
+              label: Banner 描述
+              value: 发现更多有趣的博主。
+              placeholder: 发现更多有趣的博主。
+              help: 目前仅列表模式生效
+            - $formkit: attachment
+              if: "$get(friends_template).value === 'list'"
+              name: banner_image
+              label: Banner 背景图
+              accepts:
+                - "image/*"
+              help: Banner 背景图片，目前仅列表模式生效
     - group: custom
       label: 自定义
       formSchema:

--- a/src/pages/friends.ts
+++ b/src/pages/friends.ts
@@ -1,0 +1,84 @@
+/**
+ * 朋友圈页面独立入口
+ */
+
+import "../styles/friends/main.scss";
+
+interface ArticleData {
+  author: string;
+  title: string;
+  date: string;
+  logo: string;
+  link: string;
+  description?: string;
+}
+
+/**
+ * 随机文章功能
+ */
+function initRandomArticle() {
+  const randomWrapper = document.querySelector<HTMLElement>("#fcircle-random");
+  const articles = document.querySelectorAll<HTMLAnchorElement>(".fcircle-item-container");
+
+  if (!randomWrapper || articles.length === 0) return;
+
+  // 从当前页文章提取数据
+  const articlesData: ArticleData[] = Array.from(articles).map((article) => {
+    const item = article.closest<HTMLElement>(".fcircle-item");
+    const author = article.querySelector<HTMLElement>(".fcircle-item-author")?.textContent || "";
+    const title = article.querySelector<HTMLElement>(".fcircle-item-title")?.textContent || "";
+    const date = article.querySelector<HTMLElement>(".fcircle-item-date")?.textContent || "";
+    const desc = article.querySelector<HTMLElement>(".fcircle-item-desc")?.textContent || "";
+    const logo = item?.querySelector<HTMLImageElement>(".fcircle-item-image img")?.src || "";
+    const link = article.href;
+    return { author, title, date, logo, link, description: desc };
+  });
+
+  const randomCard = randomWrapper.querySelector<HTMLAnchorElement>(".fcircle-random-card")!;
+  const refreshBtn = randomWrapper.querySelector<HTMLButtonElement>(".fcircle-random-refresh")!;
+
+  // 渲染随机卡片
+  function renderRandomCard(data: ArticleData) {
+    randomCard.innerHTML = `
+			<span class="fcircle-random-author">${data.author}</span>
+			<span class="fcircle-random-title-inner">${data.title}</span>
+			${data.date ? `<time class="fcircle-random-date">${data.date}</time>` : ""}
+		`;
+    randomCard.href = data.link;
+  }
+
+  // 随机选择并显示
+  function showRandom() {
+    if (!randomWrapper) return;
+    const randomIndex = Math.floor(Math.random() * articlesData.length);
+    renderRandomCard(articlesData[randomIndex]);
+    randomWrapper.style.display = "flex";
+  }
+
+  // 点击文章卡片跳转
+  randomCard.addEventListener("click", () => {
+    window.open(randomCard.href, "_blank");
+  });
+
+  // 点击刷新按钮
+  refreshBtn.addEventListener("click", () => {
+    refreshBtn.classList.add("is-spinning");
+    showRandom();
+    setTimeout(() => {
+      refreshBtn.classList.remove("is-spinning");
+    }, 300);
+  });
+
+  // 初始显示
+  showRandom();
+}
+
+// 自动初始化
+document.addEventListener("DOMContentLoaded", () => {
+  initRandomArticle();
+});
+
+// 支持 PJAX 页面切换后的重新初始化
+window.addEventListener("pjax:success", () => {
+  initRandomArticle();
+});

--- a/src/styles/friends/_fcircle.scss
+++ b/src/styles/friends/_fcircle.scss
@@ -1,0 +1,380 @@
+// ========================================
+// 朋友圈列表模式 (Friends Circle - List Mode)
+// ========================================
+
+@use 'variables' as *;
+@use 'mixins' as *;
+
+// ---- Banner ----
+
+.fcircle-banner {
+	position: relative;
+	min-height: 256px;
+	max-height: 320px;
+	border-radius: 8px;
+	overflow: hidden;
+	background-size: cover;
+	background-position: center;
+	background-color: var(--c-primary);
+	margin: 0 $spacing-lg $spacing-lg;
+}
+
+// 整体内容层：左上标题 + 左下描述/右下数目
+.fcircle-banner-content {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	padding: 1.25rem;
+	color: #eee;
+	text-shadow: 0 4px 5px rgba(0, 0, 0, 0.5);
+	z-index: 1;
+}
+
+.fcircle-banner-title {
+	font-size: $font-size-2xl;
+	font-weight: 700;
+}
+
+// 底部：左边描述，右边数目
+.fcircle-banner-bottom {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: $spacing-md;
+}
+
+.fcircle-banner-desc {
+	margin: 0;
+	opacity: 0.9;
+	font-size: $font-size-md;
+}
+
+.fcircle-banner-count {
+	flex-shrink: 0;
+	font-size: 0.75rem;
+	opacity: 0.7;
+
+	strong {
+		font-size: 0.85rem;
+	}
+}
+
+// ---- 页面容器 ----
+
+.page-fcircle {
+	padding: 0 $spacing-lg $spacing-lg;
+}
+
+// ---- 文章列表 ----
+
+// 随机阅读区域
+.fcircle-random-wrapper {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	margin: 1rem 0;
+}
+
+.fcircle-random-title {
+	flex-shrink: 0;
+	font-size: 1.2rem;
+	font-weight: 600;
+	color: var(--c-text-1);
+	white-space: nowrap;
+}
+
+.fcircle-random-card {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex: 1;
+	min-width: 0;
+	padding: 8px 12px;
+	border-radius: 8px;
+	box-shadow: 0 0 0 1px var(--c-bg-soft);
+	background: var(--c-bg-1);
+	text-decoration: none;
+	color: inherit;
+	transition: all $transition-fast;
+
+	&:hover {
+		box-shadow: 0 0 0 1px var(--c-primary);
+		background: var(--c-bg-2);
+
+		.fcircle-random-title-inner {
+			color: var(--c-text);
+		}
+	}
+}
+
+.fcircle-random-author {
+	flex-shrink: 0;
+	font-size: 0.85rem;
+	font-weight: 500;
+	color: var(--c-text-2);
+}
+
+.fcircle-random-title-inner {
+	flex: 1;
+	min-width: 0;
+	font-size: 0.9375rem;
+	font-weight: 600;
+	color: var(--c-text-2);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.fcircle-random-date {
+	flex-shrink: 0;
+	font-size: 0.75rem;
+	color: var(--c-text-3);
+}
+
+// 刷新按钮
+.fcircle-random-refresh {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 2.25rem;
+	height: 2.25rem;
+	padding: 0;
+	border: none;
+	border-radius: 8px;
+	background: var(--c-bg-1);
+	box-shadow: 0 0 0 1px var(--c-bg-soft);
+	color: var(--c-text-2);
+	cursor: pointer;
+	transition: all $transition-fast;
+
+	&:hover {
+		background: var(--c-bg-2);
+		color: var(--c-primary);
+		box-shadow: 0 0 0 1px var(--c-primary);
+	}
+
+	&:active {
+		transform: scale(0.95);
+	}
+
+	> [class^="icon-"] {
+		font-size: 1.1rem;
+		transition: transform $transition-slow $easing-default;
+	}
+
+	&.is-spinning > [class^="icon-"] {
+		animation: spin 0.4s ease-in-out;
+	}
+}
+
+@keyframes spin {
+	from { transform: rotate(0deg); }
+	to { transform: rotate(360deg); }
+}
+
+.fcircle-articles {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+// 列表项
+.fcircle-item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	@include animation-enter;
+}
+
+// 圆形头像容器
+.fcircle-item-image {
+	display: flex;
+	flex-shrink: 0;
+	width: 2.5rem;
+	height: 2.5rem;
+	border-radius: 50%;
+	overflow: hidden;
+	box-shadow: 0 0 0 1px var(--c-bg-soft);
+	align-self: flex-start;
+	margin-top: 6px;
+
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		opacity: 0.8;
+		transition: all $transition-fast;
+	}
+}
+
+.fcircle-item:hover .fcircle-item-image img {
+	opacity: 1;
+}
+
+.fcircle-avatar-placeholder {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 2.5rem;
+	height: 2.5rem;
+	border-radius: 50%;
+	box-shadow: 0 0 0 1px var(--c-bg-soft);
+	background: var(--c-bg-soft, var(--c-bg-2));
+	color: var(--c-text-3);
+	font-size: 1rem;
+	align-self: flex-start;
+	margin-top: 6px;
+}
+
+// 内容容器 - 两行结构
+.fcircle-item-container {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	flex: 1;
+	min-width: 0;
+	padding: 8px 10px;
+	border-radius: 8px;
+	box-shadow: 0 0 0 1px var(--c-bg-soft);
+	overflow: hidden;
+	text-decoration: none;
+	color: inherit;
+
+	&:hover .fcircle-item-title {
+		color: var(--c-text);
+	}
+}
+
+// 第一行：网站名 | 标题（截断） | 日期
+.fcircle-item-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.fcircle-item-author {
+	flex-shrink: 0;
+	font-size: 0.85rem;
+	font-weight: 500;
+	color: var(--c-text-2);
+}
+
+.fcircle-item-title {
+	flex: 1;
+	min-width: 0;
+	font-size: 0.9375rem;
+	font-weight: 600;
+	color: var(--c-text-2);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	transition: color $transition-fast;
+}
+
+.fcircle-item-date {
+	flex-shrink: 0;
+	font-size: 0.75rem;
+	color: var(--c-text-3);
+}
+
+// 第二行：摘要内容（两行截断）
+.fcircle-item-desc {
+	font-size: 0.75rem;
+	color: var(--c-text-3);
+	line-height: 1.5;
+	@include text-clamp(2);
+}
+
+// ---- 响应式 ----
+
+@media (max-width: $breakpoint-mobile) {
+	.fcircle-banner {
+		min-height: 180px;
+		margin: 0 $spacing-sm $spacing-sm;
+		border-radius: 6px;
+	}
+
+	.fcircle-banner-content {
+		padding: 1rem;
+	}
+
+	.fcircle-banner-title {
+		font-size: $font-size-xl;
+	}
+
+	.fcircle-banner-desc {
+		font-size: $font-size-sm;
+	}
+
+	.page-fcircle {
+		padding: 0 $spacing-sm $spacing-sm;
+	}
+
+	.fcircle-item-image,
+	.fcircle-avatar-placeholder {
+		width: 2rem;
+		height: 2rem;
+		margin-top: 4px;
+	}
+
+	.fcircle-item-container {
+		padding: 6px 8px;
+	}
+
+	.fcircle-item-desc {
+		@include text-clamp(1);
+	}
+
+	.fcircle-item-author {
+		font-size: 0.75rem;
+	}
+
+	.fcircle-item-title {
+		font-size: 0.85rem;
+	}
+
+	.fcircle-item-date {
+		font-size: 0.7rem;
+	}
+
+	.fcircle-random-wrapper {
+		flex-direction: column;
+		align-items: stretch;
+		gap: 8px;
+	}
+
+	.fcircle-random-title {
+		font-size: $font-size-md;
+	}
+
+	.fcircle-random-card {
+		padding: 6px 10px;
+	}
+
+	.fcircle-random-author {
+		font-size: 0.75rem;
+	}
+
+	.fcircle-random-title-inner {
+		font-size: 0.85rem;
+	}
+
+	.fcircle-random-date {
+		font-size: 0.7rem;
+	}
+
+	.fcircle-random-refresh {
+		width: 2rem;
+		height: 2rem;
+
+		> [class^="icon-"] {
+			font-size: 1rem;
+		}
+	}
+}

--- a/src/styles/friends/main.scss
+++ b/src/styles/friends/main.scss
@@ -11,4 +11,5 @@
 @use 'card';
 @use 'content';
 @use 'empty';
+@use 'fcircle';
 @use 'pagination';

--- a/templates/friends.html
+++ b/templates/friends.html
@@ -1,81 +1,156 @@
 <!doctype html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = '朋友圈', head = ~{::head})}"
+  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = ${theme.config.plugins?.friends?.title ?: '朋友圈'}, head = ~{::head})}"
 >
   <th:block th:fragment="head">
     <th:block th:replace="~{modules/head :: friends-head}" />
   </th:block>
-  <th:block th:fragment="content">
-    <div class="friends-header">
-      <div class="friends-title">
-        <span class="icon-[ph--rss-bold]"></span>
-        <h1 class="text-creative">朋友圈</h1>
+  <th:block th:fragment="content" th:with="friendsConfig=${theme.config.plugins?.friends}">
+    <!--/* ========== 卡片模式（默认） ========== */-->
+    <th:block th:if="${friendsConfig == null or friendsConfig.template == null or friendsConfig.template == 'card'}">
+      <div class="friends-header">
+        <div class="friends-title">
+          <span class="icon-[ph--rss-bold]"></span>
+          <h1 class="text-creative">朋友圈</h1>
+        </div>
+        <div class="friends-actions">
+          <span class="friends-count" th:if="${friends.total > 0}">
+            共 <strong th:text="${friends.total}"></strong> 篇订阅
+          </span>
+          <a th:if="${theme.config.links?.enable_submit}" href="/links#add" class="apply-link" title="申请友链">
+            <span class="icon-[ph--handshake-bold]"></span>
+            申请友链
+          </a>
+        </div>
       </div>
-      <div class="friends-actions">
-        <span class="friends-count" th:if="${friends.total > 0}">
-          共 <strong th:text="${friends.total}"></strong> 篇订阅
-        </span>
-        <a th:if="${theme.config.links?.enable_submit}" href="/links#add" class="apply-link" title="申请友链">
-          <span class="icon-[ph--handshake-bold]"></span>
-          申请友链
-        </a>
-      </div>
-    </div>
 
-    <div class="friends-list proper-height">
-      <article
-        th:each="friend,iterStat : ${friends.items}"
-        th:with="spec=${friend.spec}"
-        class="friend-card"
-        th:style="'--delay: ' + ${iterStat.index * 0.03} + 's'"
+      <div class="friends-list proper-height">
+        <article
+          th:each="friend,iterStat : ${friends.items}"
+          th:with="spec=${friend.spec}"
+          class="friend-card"
+          th:style="'--delay: ' + ${iterStat.index * 0.03} + 's'"
+        >
+          <header class="friend-header">
+            <a th:href="${spec.authorUrl}" target="_blank" rel="noopener" class="author-info">
+              <img
+                th:if="${spec.logo != null and spec.logo != ''}"
+                th:src="${spec.logo}"
+                th:alt="${spec.author}"
+                class="author-avatar"
+                loading="lazy"
+              />
+              <span th:unless="${spec.logo != null and spec.logo != ''}" class="author-avatar-placeholder">
+                <span class="icon-[ph--user-bold]"></span>
+              </span>
+              <span class="author-name" th:text="${spec.author}">作者</span>
+            </a>
+            <time
+              th:if="${spec.pubDate != null}"
+              class="friend-time"
+              th:datetime="${spec.pubDate}"
+              th:text="${#temporals.format(spec.pubDate, 'MM-dd')}"
+            ></time>
+          </header>
+
+          <a th:href="${spec.postLink}" target="_blank" rel="noopener" class="friend-content">
+            <h2 class="friend-title" th:text="${spec.title}">文章标题</h2>
+            <p
+              th:if="${spec.description != null and spec.description != ''}"
+              class="friend-desc"
+              th:text="${spec.description}"
+            ></p>
+          </a>
+
+          <footer class="friend-footer">
+            <a th:href="${spec.postLink}" target="_blank" rel="noopener" class="read-more">
+              <span>阅读原文</span>
+              <span class="icon-[ph--arrow-up-right-bold]"></span>
+            </a>
+          </footer>
+        </article>
+
+        <div th:if="${#lists.isEmpty(friends.items)}" class="friends-empty">
+          <span class="icon-[ph--rss-bold]"></span>
+          <p>暂无订阅内容</p>
+          <span class="empty-hint">去添加一些友链的 RSS 订阅吧</span>
+        </div>
+
+        <th:block th:replace="~{modules/pagination :: pagination(data=${friends})}" />
+      </div>
+    </th:block>
+
+    <!--/* ========== 列表模式 ========== */-->
+    <th:block th:if="${friendsConfig != null and friendsConfig.template == 'list'}">
+      <div
+        class="fcircle-banner"
+        th:style="${friendsConfig.banner_image != null and friendsConfig.banner_image != ''} ? 'background-image: url(' + ${friendsConfig.banner_image} + ')' : ''"
       >
-        <header class="friend-header">
-          <a th:href="${spec.authorUrl}" target="_blank" rel="noopener" class="author-info">
-            <img
-              th:if="${spec.logo != null and spec.logo != ''}"
-              th:src="${spec.logo}"
-              th:alt="${spec.author}"
-              class="author-avatar"
-              loading="lazy"
-            />
-            <span th:unless="${spec.logo != null and spec.logo != ''}" class="author-avatar-placeholder">
+        <div class="fcircle-banner-content">
+          <h1 class="fcircle-banner-title" th:text="${friendsConfig.title ?: '朋友圈'}">朋友圈</h1>
+          <div class="fcircle-banner-bottom">
+            <p class="fcircle-banner-desc" th:text="${friendsConfig.banner_desc ?: '发现更多有趣的博主。'}">
+              发现更多有趣的博主。
+            </p>
+            <span class="fcircle-banner-count" th:if="${friends.total > 0}">
+              <strong th:text="${friends.total}"></strong> 篇文章
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div class="page-fcircle proper-height">
+        <div class="fcircle-random-wrapper" id="fcircle-random" style="display: none">
+          <span class="fcircle-random-title">随机阅读</span>
+          <a class="fcircle-random-card" href="#" target="_blank" rel="noopener">
+            <!-- 由 JS 填充 -->
+          </a>
+          <button class="fcircle-random-refresh" title="换一个">
+            <span class="icon-[ph--arrows-clockwise-bold]"></span>
+          </button>
+        </div>
+        <div class="fcircle-articles">
+          <div
+            th:each="friend,iterStat : ${friends.items}"
+            th:with="spec=${friend.spec}"
+            class="fcircle-item"
+            th:style="'--delay: ' + ${iterStat.index * 0.03} + 's'"
+          >
+            <div th:if="${spec.logo != null and spec.logo != ''}" class="fcircle-item-image">
+              <img th:src="${spec.logo}" th:alt="${spec.author}" loading="lazy" />
+            </div>
+            <span th:unless="${spec.logo != null and spec.logo != ''}" class="fcircle-avatar-placeholder">
               <span class="icon-[ph--user-bold]"></span>
             </span>
-            <span class="author-name" th:text="${spec.author}">作者</span>
-          </a>
-          <time
-            th:if="${spec.pubDate != null}"
-            class="friend-time"
-            th:datetime="${spec.pubDate}"
-            th:text="${#temporals.format(spec.pubDate, 'MM-dd')}"
-          ></time>
-        </header>
+            <a th:href="${spec.postLink}" target="_blank" rel="noopener" class="fcircle-item-container gradient-card">
+              <div class="fcircle-item-header">
+                <span class="fcircle-item-author" th:text="${spec.author}">网站名</span>
+                <span class="fcircle-item-title" th:text="${spec.title}">文章标题</span>
+                <time
+                  th:if="${spec.pubDate != null}"
+                  class="fcircle-item-date"
+                  th:datetime="${spec.pubDate}"
+                  th:text="${#temporals.format(spec.pubDate, 'yyyy-MM-dd')}"
+                ></time>
+              </div>
+              <span
+                th:if="${spec.description != null and spec.description != ''}"
+                class="fcircle-item-desc"
+                th:text="${spec.description}"
+              ></span>
+            </a>
+          </div>
+        </div>
 
-        <a th:href="${spec.postLink}" target="_blank" rel="noopener" class="friend-content">
-          <h2 class="friend-title" th:text="${spec.title}">文章标题</h2>
-          <p
-            th:if="${spec.description != null and spec.description != ''}"
-            class="friend-desc"
-            th:text="${spec.description}"
-          ></p>
-        </a>
+        <div th:if="${#lists.isEmpty(friends.items)}" class="friends-empty">
+          <span class="icon-[ph--rss-bold]"></span>
+          <p>暂无订阅内容</p>
+          <span class="empty-hint">去添加一些友链的 RSS 订阅吧</span>
+        </div>
 
-        <footer class="friend-footer">
-          <a th:href="${spec.postLink}" target="_blank" rel="noopener" class="read-more">
-            <span>阅读原文</span>
-            <span class="icon-[ph--arrow-up-right-bold]"></span>
-          </a>
-        </footer>
-      </article>
-
-      <div th:if="${#lists.isEmpty(friends.items)}" class="friends-empty">
-        <span class="icon-[ph--rss-bold]"></span>
-        <p>暂无订阅内容</p>
-        <span class="empty-hint">去添加一些友链的 RSS 订阅吧</span>
+        <th:block th:replace="~{modules/pagination :: pagination(data=${friends})}" />
       </div>
-
-      <th:block th:replace="~{modules/pagination :: pagination(data=${friends})}" />
-    </div>
+    </th:block>
   </th:block>
 </html>

--- a/templates/modules/head.html
+++ b/templates/modules/head.html
@@ -40,6 +40,11 @@
     data-pjax-conditional="friends"
     th:href="@{/assets/dist/friends.css?v={version}(version=${theme.spec.version})}"
   />
+  <script
+    type="module"
+    data-pjax-conditional="friends"
+    th:src="@{/assets/dist/friends.js?v={version}(version=${theme.spec.version})}"
+  ></script>
 </th:block>
 
 <th:block th:fragment="bangumis-head">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default ({ mode }: { mode: string }) => {
     shop: path.resolve(__dirname, "src/styles/shop/main.scss"),
     moments: path.resolve(__dirname, "src/pages/moments.ts"),
     links: path.resolve(__dirname, "src/pages/links.ts"),
-    friends: path.resolve(__dirname, "src/styles/friends/main.scss"),
+    friends: path.resolve(__dirname, "src/pages/friends.ts"),
     bangumis: path.resolve(__dirname, "src/styles/bangumis/main.scss"),
     photos: path.resolve(__dirname, "src/styles/photos/main.scss"),
     steam: path.resolve(__dirname, "src/styles/steam/main.scss"),


### PR DESCRIPTION
## 概述

  为 `/friends` 朋友圈页面添加一套新的列表风格模板，参考 https://blog.linux-qitong.top/fcircle
  的紧凑列表设计。新模板与现有卡片模板共存，通过设置切换。

  **关联 Issue**: #87

  ## 功能

  ### 新增配置（插件适配 → 朋友圈）
  - **模板样式**：卡片模式（默认）/ 列表模式
  - **页面标题**：设置页面标题和浏览器标签标题
  - **Banner 描述**：仅列表模式生效
  - **Banner 背景图**：仅列表模式生效

  ### 列表模式特性
  - **全宽 Banner**：背景图 + 标题 + 描述 + 文章统计
  - **随机阅读**：点击文章跳转，点击刷新按钮换一篇
  - **紧凑列表**：头像 | 网站名 标题 日期 + 摘要（两行截断）
  - **响应式**：移动端优化布局

  ## 文件变更

  | 文件 | 说明 |
  |------|------|
  | `settings.yaml` | 新增 friends 配置组 |
  | `templates/friends.html` | 条件渲染双模板 |
  | `templates/modules/head.html` | friends.js 引入 |
  | `src/pages/friends.ts` | 随机阅读功能 |
  | `src/styles/friends/_fcircle.scss` | 列表模式样式 |
  | `src/styles/friends/main.scss` | 引入 fcircle 模块 |
  | `vite.config.ts` | friends 入口改为 TS

