### PR TITLE
feat(friends): 优化朋友圈列表模式

### DIFF
--- a/src/styles/friends/_fcircle.scss
+++ b/src/styles/friends/_fcircle.scss
@@ -16,7 +16,7 @@
 	background-size: cover;
 	background-position: center;
 	background-color: var(--c-primary);
-	margin: 0 $spacing-lg $spacing-lg;
+	margin: $spacing-xl $spacing-lg $spacing-lg;
 }
 
 // 整体内容层：左上标题 + 左下描述/右下数目
@@ -296,7 +296,7 @@
 @media (max-width: $breakpoint-mobile) {
 	.fcircle-banner {
 		min-height: 180px;
-		margin: 0 $spacing-sm $spacing-sm;
+		margin: $spacing-xl $spacing-sm $spacing-sm;
 		border-radius: 6px;
 	}
 
@@ -344,9 +344,12 @@
 	}
 
 	.fcircle-random-wrapper {
-		flex-direction: column;
-		align-items: stretch;
+		flex-wrap: wrap;
 		gap: 8px;
+	}
+
+	.fcircle-random-title {
+		width: 100%;
 	}
 
 	.fcircle-random-title {

--- a/templates/friends.html
+++ b/templates/friends.html
@@ -12,7 +12,7 @@
       <div class="friends-header">
         <div class="friends-title">
           <span class="icon-[ph--rss-bold]"></span>
-          <h1 class="text-creative">朋友圈</h1>
+          <h1 class="text-creative" th:text="${friendsConfig?.title ?: '朋友圈'}">朋友圈</h1>
         </div>
         <div class="friends-actions">
           <span class="friends-count" th:if="${friends.total > 0}">
@@ -117,12 +117,24 @@
             class="fcircle-item"
             th:style="'--delay: ' + ${iterStat.index * 0.03} + 's'"
           >
-            <div th:if="${spec.logo != null and spec.logo != ''}" class="fcircle-item-image">
+            <a
+              th:href="${spec.authorUrl}"
+              target="_blank"
+              rel="noopener"
+              class="fcircle-item-image"
+              th:if="${spec.logo != null and spec.logo != ''}"
+            >
               <img th:src="${spec.logo}" th:alt="${spec.author}" loading="lazy" />
-            </div>
-            <span th:unless="${spec.logo != null and spec.logo != ''}" class="fcircle-avatar-placeholder">
+            </a>
+            <a
+              th:href="${spec.authorUrl}"
+              target="_blank"
+              rel="noopener"
+              th:unless="${spec.logo != null and spec.logo != ''}"
+              class="fcircle-avatar-placeholder"
+            >
               <span class="icon-[ph--user-bold]"></span>
-            </span>
+            </a>
             <a th:href="${spec.postLink}" target="_blank" rel="noopener" class="fcircle-item-container gradient-card">
               <div class="fcircle-item-header">
                 <span class="fcircle-item-author" th:text="${spec.author}">网站名</span>


### PR DESCRIPTION
- 列表模式头像添加链接，点击跳转朋友站点
- 移动端随机区域布局优化，卡片与刷新按钮同行显示
- 卡片模式标题支持读取 settings.yaml 配置
- 列表模式 banner 顶部增加间距