### PR TITLE
feat(moments): 添加瞬间列表模式模板

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1208,6 +1208,18 @@ spec:
           label: 瞬间插件
           help: plugin-moments
           children:
+            - $formkit: select
+              name: template
+              id: moments_template
+              key: moments_template
+              label: 模板样式
+              value: card
+              help: 选择瞬间页面的展示模板
+              options:
+                - value: card
+                  label: 卡片模式（默认）
+                - value: list
+                  label: 列表模式
             - $formkit: text
               name: title
               label: 页面标题
@@ -1220,6 +1232,20 @@ spec:
               value: 瞬间详情
               placeholder: 瞬间详情
               validation: required
+            - $formkit: text
+              if: "$get(moments_template).value === 'list'"
+              name: banner_desc
+              label: Banner 描述
+              value: 记录生活中的点滴瞬间。
+              placeholder: 记录生活中的点滴瞬间。
+              help: 仅列表模式生效
+            - $formkit: attachment
+              if: "$get(moments_template).value === 'list'"
+              name: banner_image
+              label: Banner 背景图
+              accepts:
+                - "image/*"
+              help: Banner 背景图片，仅列表模式生效
         - $formkit: group
           name: photos
           label: 图库插件

--- a/src/styles/moments/_detail-list.scss
+++ b/src/styles/moments/_detail-list.scss
@@ -1,0 +1,242 @@
+// ========================================
+// 列表模板详情页
+// ========================================
+.moment-detail-list {
+	margin: 0 1rem 1.5rem;
+	animation: fade-slide-up 0.4s 0.1s both;
+
+	.moment-header {
+		display: flex !important;
+		align-items: flex-start !important;
+		justify-content: flex-start !important;
+		gap: 0.6rem;
+		margin-bottom: 0.75rem;
+
+		.author-avatar {
+			width: 3em !important;
+			height: 3em !important;
+			border-radius: 2em !important;
+			box-shadow: 2px 4px 1rem var(--ld-shadow) !important;
+			flex-shrink: 0;
+		}
+
+		.author-name {
+			display: flex !important;
+			flex-direction: column !important;
+			gap: 0.15rem;
+			font-weight: 600;
+			font-size: 0.95rem;
+			color: var(--c-text-1) !important;
+		}
+
+		.moment-time {
+			font-size: 0.75rem;
+			color: var(--c-text-3);
+			background-color: transparent !important;
+			padding: 0 !important;
+			display: inline !important;
+		}
+	}
+
+	.moment-body {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		margin-top: 0.75rem;
+		animation: fade-in 0.4s 0.2s both;
+	}
+
+	.moment-text {
+		font-size: 0.95rem;
+		line-height: 1.7;
+		color: var(--c-text-1);
+
+		.tag,
+		[class*="tag"] {
+			display: none;
+		}
+	}
+
+	.moment-media {
+		margin-top: 0.5rem;
+		display: grid;
+		gap: 8px;
+		animation: fade-scale-in 0.4s 0.3s both;
+
+		&.single {
+			grid-template-columns: 1fr;
+
+			.media-item {
+				overflow: hidden;
+				border-radius: 8px;
+				box-shadow: 0 1px 3px color-mix(in srgb, var(--ld-shadow), transparent 85%);
+
+				img, video {
+					display: block;
+					width: 100%;
+					max-height: 70vh;
+					object-fit: cover;
+					cursor: zoom-in;
+				}
+			}
+		}
+
+		&.double {
+			grid-template-columns: repeat(2, 1fr);
+		}
+
+		&.grid {
+			grid-template-columns: repeat(3, 1fr);
+		}
+
+		&.double .media-item,
+		&.grid .media-item {
+			position: relative;
+			padding-bottom: 100%;
+			overflow: hidden;
+			border-radius: 8px;
+			box-shadow: 0 1px 3px color-mix(in srgb, var(--ld-shadow), transparent 85%);
+
+			img, video {
+				position: absolute;
+				inset: 0;
+				width: 100%;
+				height: 100%;
+				object-fit: cover;
+				cursor: zoom-in;
+				transition: transform 0.3s;
+
+				&:hover {
+					transform: scale(1.02);
+				}
+			}
+		}
+
+		.media-item.audio {
+			grid-column: 1 / -1;
+			padding-bottom: 0;
+			position: static;
+
+			audio {
+				width: 100%;
+			}
+		}
+	}
+
+	.moment-footer {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-top: 0.75rem;
+		padding-top: 0.5rem;
+		border-top: 1px dashed var(--c-border);
+		animation: fade-in 0.3s 0.4s both;
+
+		.moment-tags {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 4px;
+			margin: 0;
+			padding: 0;
+		}
+
+		.moment-tag {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.15rem;
+			padding: 2px 6px;
+			border-radius: 4px;
+			background-color: var(--c-bg-2);
+			color: var(--c-primary);
+			font-size: 0.75rem;
+			text-decoration: none;
+			transition: all 0.2s;
+
+			[class^="icon-"] {
+				font-size: 0.85em;
+			}
+
+			&:hover {
+				color: #fff;
+				background-color: var(--c-primary);
+			}
+		}
+
+		.moment-actions {
+			display: flex;
+			gap: 0.25rem;
+			margin-left: auto;
+		}
+	}
+
+	@media (max-width: 640px) {
+		margin: 0 0.5rem 1rem;
+
+		.moment-header {
+			.author-avatar {
+				width: 2.5em;
+				height: 2.5em;
+			}
+
+			.author-name {
+				font-size: 0.85rem;
+			}
+
+			.moment-time {
+				font-size: 0.7rem;
+			}
+		}
+
+		.moment-body {
+			.moment-text {
+				font-size: 0.9rem;
+			}
+		}
+
+		.moment-footer {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.5rem;
+
+			.moment-actions {
+				margin-left: 0;
+				width: 100%;
+				justify-content: flex-end;
+			}
+		}
+
+		.moment-media {
+			&.single .media-item img,
+			&.single .media-item video {
+				max-height: 50vh;
+			}
+		}
+	}
+}
+
+// 列表模式返回按钮（简化版）
+.moment-back-simple {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+
+	.back-link {
+		padding: 0.3em 0.6em;
+		font-size: 0.75rem;
+		color: var(--c-text-3);
+		background-color: transparent;
+
+		[class^="icon-"] {
+			font-size: 1em;
+		}
+
+		&:hover {
+			color: var(--c-primary);
+			background-color: var(--c-primary-soft);
+
+			[class^="icon-"] {
+				transform: none;
+			}
+		}
+	}
+}

--- a/src/styles/moments/_list.scss
+++ b/src/styles/moments/_list.scss
@@ -1,0 +1,586 @@
+// ========================================
+// 瞬间列表模式 (Moments - List Mode)
+// 参考 blog.linux-qitong.top/essay 的 .talk-item 风格
+// 每条瞬间是独立卡片，box-shadow 边框，垂直布局
+// ========================================
+
+// ---- Banner ----
+
+.moments-banner {
+  position: relative;
+  min-height: 256px;
+  max-height: 320px;
+  border-radius: 8px;
+  overflow: hidden;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--c-primary);
+  margin: 1rem 1rem 1rem;
+}
+
+.moments-banner-content {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1.25rem;
+  color: #eee;
+  text-shadow: 0 4px 5px rgba(0, 0, 0, 0.5);
+  z-index: 1;
+}
+
+.moments-banner-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.moments-banner-bottom {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.moments-banner-desc {
+  margin: 0;
+  opacity: 0.9;
+  font-size: 0.9rem;
+}
+
+.moments-banner-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.moments-banner-count {
+  font-size: 0.75rem;
+  opacity: 0.7;
+
+  strong {
+    font-size: 0.85rem;
+  }
+}
+
+.moments-banner-rss {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.15);
+  color: #eee;
+  font-size: 0.85rem;
+  transition: all 0.2s;
+  text-decoration: none;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.3);
+    color: #fff;
+    transform: scale(1.1);
+  }
+}
+
+// ---- 列表模式标签栏 ----
+
+.moments-list-tags {
+  // 不加额外 margin，内部 .moments-tags-wrapper 自带 margin: 0 1rem
+  .moments-tags {
+    gap: 0.4rem;
+  }
+
+  .tag-item {
+    padding: 0.3em 0.75em;
+    border-radius: 2em;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--c-text-2);
+    background: var(--c-bg-1);
+    box-shadow: 0 0 0 1px var(--c-bg-soft);
+    transition: all 0.2s;
+    white-space: nowrap;
+
+    &:hover {
+      color: var(--c-primary);
+      box-shadow: 0 0 0 1px var(--c-primary);
+      background: var(--c-bg-2);
+    }
+
+    &.active {
+      color: #fff;
+      background: var(--c-primary);
+      box-shadow: none;
+    }
+
+    .tag-count {
+      margin-left: 0.2em;
+      font-size: 0.9em;
+      opacity: 0.7;
+    }
+  }
+}
+
+// ---- 列表容器 ----
+
+.page-moments-list {
+  padding: 0 1rem 1rem;
+
+  .pagination-wrapper.sticky-pagination.expand {
+    width: 100%;
+  }
+}
+
+// ---- 列表项 ----
+
+.moment-list-items {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.moment-list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 0 0 1px var(--c-bg-soft);
+  animation: float-in 0.3s var(--delay, 0s) both;
+  transition: box-shadow 0.2s;
+
+  &:hover {
+    box-shadow: 0 0 0 1px var(--c-primary-soft);
+  }
+}
+
+// ---- 头部：头像 + 昵称/日期（上下排列） ----
+
+.moment-list-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.moment-list-avatar {
+  width: 3em;
+  border-radius: 2em;
+  object-fit: cover;
+  box-shadow: 2px 4px 1rem var(--ld-shadow);
+  flex-shrink: 0;
+}
+
+.moment-list-avatar-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 3em;
+  height: 3em;
+  border-radius: 2em;
+  background: var(--c-bg-soft, var(--c-bg-2));
+  box-shadow: 2px 4px 1rem var(--ld-shadow);
+  color: var(--c-text-3);
+  font-size: 1.2rem;
+}
+
+.moment-list-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.moment-list-nick {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--c-text-1);
+}
+
+.moment-list-date {
+  color: var(--c-text-3);
+  font-size: 0.8rem;
+}
+
+// ---- 正文 ----
+
+.moment-list-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: var(--c-text-2);
+  line-height: 1.6;
+
+  .moment-text {
+    font-size: 0.85rem;
+    line-height: 1.7;
+    color: var(--c-text-1);
+
+    .tag,
+    [class*="tag"] {
+      display: none;
+    }
+
+    p {
+      margin: 0.3em 0;
+      &:first-child {
+        margin-top: 0;
+      }
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+      margin: 0.5em 0 0.25em;
+      font-weight: 600;
+      line-height: 1.35;
+      color: var(--c-text-1);
+      &:first-child {
+        margin-top: 0;
+      }
+    }
+
+    h1 { font-size: 1.1em; }
+    h2 { font-size: 1.05em; }
+    h3, h4, h5, h6 { font-size: 1em; }
+
+    a {
+      color: var(--c-primary);
+      text-decoration: none;
+      background: linear-gradient(var(--c-primary-soft), var(--c-primary-soft)) no-repeat bottom / 100% 0.1em;
+      margin: -0.1em -0.2em;
+      padding: 0.1em 0.2em;
+      transition: all 0.2s;
+
+      &:hover {
+        background-size: 100% 100%;
+        border-radius: 0.3em;
+      }
+    }
+
+    ul, ol {
+      margin: 0.3em 0;
+      padding-left: 1.25em;
+    }
+
+    ul {
+      list-style: disc;
+      ul { list-style: circle; }
+    }
+
+    ol { list-style: decimal; }
+
+    li {
+      margin: 0.15em 0;
+      padding-left: 0.25em;
+      &::marker { color: var(--c-primary); }
+    }
+
+    code {
+      padding: 0.1em 0.3em;
+      border-radius: 0.2em;
+      background-color: var(--c-bg-soft);
+      font-family: var(--font-monospace);
+      font-size: 0.9em;
+      color: var(--c-accent);
+    }
+
+    pre {
+      margin: 0.4em 0;
+      padding: 0.5em 0.7em;
+      border-radius: 0.4em;
+      background-color: var(--c-bg-soft);
+      overflow-x: auto;
+      font-size: 0.8em;
+
+      code {
+        padding: 0;
+        background: none;
+        color: inherit;
+      }
+    }
+
+    blockquote {
+      margin: 0.4em 0;
+      padding: 0.3em 0.6em;
+      border-left: 2px solid var(--c-primary);
+      background-color: var(--c-primary-soft);
+      border-radius: 0 0.2em 0.2em 0;
+      color: var(--c-text-2);
+      font-size: 0.95em;
+
+      p { margin: 0.1em 0; }
+    }
+
+    strong, b {
+      font-weight: 600;
+      color: var(--c-text-1);
+    }
+
+    em, i { font-style: italic; }
+
+    del, s {
+      text-decoration: line-through;
+      color: var(--c-text-3);
+    }
+
+    hr {
+      margin: 0.6em 0;
+      border: none;
+      border-top: 1px dashed var(--c-border);
+    }
+
+    img {
+      max-width: 100%;
+      border-radius: 0.25em;
+    }
+  }
+
+  // ---- 列表模式下的媒体 ----
+  // 与参考站一致：所有图片统一走 3 列网格 + 正方形裁切
+  .moment-media {
+    margin-top: 0;
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(3, 1fr);
+
+    &.single,
+    &.double,
+    &.grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 8px;
+    }
+
+    .media-item {
+      margin: 0;
+      border-radius: 8px;
+      overflow: hidden;
+      position: relative;
+      padding-bottom: 100%;
+
+      &.photo img,
+      &.video video {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        cursor: zoom-in;
+        transition: transform 0.3s;
+
+        &:hover {
+          transform: scale(1.05);
+        }
+      }
+
+      // 音频横跨整行
+      &.audio {
+        grid-column: 1 / -1;
+        padding-bottom: 0;
+        position: static;
+
+        audio {
+          position: static;
+          width: 100%;
+        }
+      }
+    }
+  }
+}
+
+// ---- 底部：标签 + 操作按钮 ----
+
+.moment-list-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--c-text-3);
+}
+
+.moment-list-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  font-size: 0.7rem;
+}
+
+.moment-list-tag {
+  display: flex;
+  align-items: center;
+  gap: 0.15em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background-color: var(--c-bg-2);
+  color: var(--c-primary);
+  text-decoration: none;
+  transition: all 0.2s;
+
+  [class^="icon-"] {
+    font-size: 0.85em;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: var(--c-primary);
+  }
+}
+
+.moment-list-bottom .moment-actions {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+.moment-list-bottom .action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.3em 0.5em;
+  border-radius: 2em;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--c-text-3);
+  background-color: transparent;
+  transition: all 0.2s;
+
+  [class^="icon-"],
+  .iconify {
+    font-size: 1.1em;
+  }
+
+  &:hover {
+    background-color: var(--c-bg-soft);
+    color: var(--c-text-1);
+  }
+
+  &.comment:hover {
+    background-color: var(--c-primary-soft);
+    color: var(--c-primary);
+  }
+
+  &.comment:has(span:not([class])):not(:has(span:empty)) {
+    background-color: var(--c-bg-soft);
+  }
+
+  &.share:hover {
+    background-color: color-mix(in srgb, var(--c-accent), transparent 85%);
+    color: var(--c-accent);
+  }
+
+  &.share.copied {
+    background-color: #dcfce7;
+    color: #16a34a;
+
+    .dark & {
+      background-color: rgba(34, 197, 94, 0.15);
+      color: #4ade80;
+    }
+
+    [class^="icon-"],
+    .iconify {
+      display: none;
+    }
+
+    &::before {
+      content: "✓ 已复制";
+      font-weight: 600;
+    }
+  }
+
+  &.like {
+    &:hover {
+      background-color: rgba(239, 68, 68, 0.1);
+      color: #ef4444;
+    }
+
+    &.active {
+      background-color: rgba(239, 68, 68, 0.1);
+      color: #ef4444;
+
+      .dark & {
+        background-color: rgba(239, 68, 68, 0.15);
+      }
+    }
+
+    &.loading {
+      opacity: 0.6;
+      pointer-events: none;
+    }
+
+    &.active [class*="heart-fill"] {
+      animation: like-pop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    }
+  }
+}
+
+// 列表模式评论区
+.moment-list-item .moment-comment {
+  margin-top: 0.25rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--c-border);
+}
+
+// ---- 响应式 ----
+
+@media (max-width: 640px) {
+  .moments-banner {
+    min-height: 180px;
+    margin: 1.5rem 0.5rem 0.5rem;
+    border-radius: 6px;
+  }
+
+  .moments-banner-content {
+    padding: 1rem;
+  }
+
+  .moments-banner-title {
+    font-size: 1.1rem;
+  }
+
+  .moments-banner-desc {
+    font-size: 0.8rem;
+  }
+
+  .moments-list-tags {
+    .moments-tags-wrapper {
+      margin: 0 0.5rem 0.5rem;
+    }
+  }
+
+  .page-moments-list {
+    padding: 0 0.5rem 0.5rem;
+  }
+
+  .moment-list-items {
+    gap: 0.75rem;
+  }
+
+  .moment-list-item {
+    padding: 0.75rem;
+  }
+
+  .moment-list-avatar,
+  .moment-list-avatar-placeholder {
+    width: 2.5em;
+    height: 2.5em;
+  }
+
+  .moment-list-nick {
+    font-size: 0.8rem;
+  }
+
+  .moment-list-date {
+    font-size: 0.7rem;
+  }
+
+  .moment-list-content {
+    .moment-text {
+      font-size: 0.8rem;
+    }
+  }
+}

--- a/src/styles/moments/main.scss
+++ b/src/styles/moments/main.scss
@@ -5,9 +5,11 @@
 @use 'header';
 @use 'tags';
 @use 'card';
+@use 'list';
 @use 'media';
 @use 'actions';
 @use 'comments';
 @use 'detail';
+@use 'detail-list';
 @use 'pagination';
 @use 'empty';

--- a/templates/modules/moment/list-card.html
+++ b/templates/modules/moment/list-card.html
@@ -1,0 +1,89 @@
+<th:block th:fragment="content">
+  <article
+    th:each="moment,iterStat : ${moments.items}"
+    th:with="content=${moment.spec.content}, twikooEnabled=${theme.config.comment?.provider == 'twikoo'}"
+    class="moment-list-item"
+    th:id="|moment-${moment.metadata.name}|"
+    th:style="'--delay: ' + ${iterStat.index * 0.05} + 's'"
+  >
+    <!-- 头部：头像 + 作者信息（昵称/时间上下排列） -->
+    <div class="moment-list-meta">
+      <img
+        th:if="${moment.owner != null and moment.owner.avatar != null}"
+        th:src="${moment.owner.avatar}"
+        th:alt="${moment.owner.displayName}"
+        class="moment-list-avatar"
+        loading="lazy"
+      />
+      <span th:unless="${moment.owner != null and moment.owner.avatar != null}" class="moment-list-avatar-placeholder">
+        <span class="icon-[ph--user-bold]"></span>
+      </span>
+      <div class="moment-list-info">
+        <div th:if="${moment.owner != null}" class="moment-list-nick">
+          <span th:text="${moment.owner.displayName}"></span>
+        </div>
+        <time
+          class="moment-list-date"
+          th:datetime="${moment.spec.releaseTime}"
+          th:title="${#temporals.format(moment.spec.releaseTime, 'yyyy-MM-dd HH:mm')}"
+          th:text="${#temporals.format(moment.spec.releaseTime, 'yyyy-MM-dd HH:mm')}"
+        ></time>
+      </div>
+    </div>
+
+    <!-- 正文 + 媒体 -->
+    <div class="moment-list-content">
+      <div th:if="${not #strings.isEmpty(content.html)}" class="moment-text" th:utext="${content.html}"></div>
+
+      <th:block th:replace="~{modules/moment/common :: media}"></th:block>
+    </div>
+
+    <!-- 底部：标签 + 操作按钮 -->
+    <div class="moment-list-bottom">
+      <div th:if="${not #lists.isEmpty(moment.spec.tags)}" class="moment-list-tags">
+        <a th:each="tag : ${moment.spec.tags}" th:href="|/moments?tag=${tag}|" class="moment-list-tag">
+          <span class="icon-[ph--tag-bold]"></span>
+          <span th:text="${tag}"></span>
+        </a>
+      </div>
+
+      <div class="moment-actions">
+        <th:block th:replace="~{modules/moment/common :: like-button}"></th:block>
+        <button
+          th:if="${haloCommentEnabled and !twikooEnabled}"
+          class="action-btn comment"
+          title="评论"
+          onclick="this.closest('.moment-list-item').querySelector('.moment-comment')?.classList.toggle('show')"
+        >
+          <span class="icon-[ph--chat-circle-bold]"></span>
+          <span th:text="${moment.stats.approvedComment ?: 0}"></span>
+        </button>
+        <a
+          th:if="${twikooEnabled}"
+          class="action-btn comment"
+          title="查看评论"
+          th:href="|/moments/${moment.metadata.name}#comment|"
+        >
+          <span class="icon-[ph--chat-circle-bold]"></span>
+          <span th:text="${moment.stats.approvedComment ?: 0}"></span>
+        </a>
+        <th:block
+          th:replace="~{modules/moment/common :: share-button(url=|/moments/${moment.metadata.name}|)}"
+        ></th:block>
+      </div>
+    </div>
+
+    <!-- 评论区折叠 -->
+    <div
+      th:if="${haloCommentEnabled and !twikooEnabled}"
+      class="moment-comment"
+      th:id="|comment-${moment.metadata.name}|"
+    >
+      <div class="comment-header">
+        <span class="icon-[ph--chat-circle-text-bold]"></span>
+        <span>评论</span>
+      </div>
+      <halo:comment group="moment.halo.run" kind="Moment" th:attr="name=${moment.metadata.name}" />
+    </div>
+  </article>
+</th:block>

--- a/templates/moment.html
+++ b/templates/moment.html
@@ -6,56 +6,112 @@
   <th:block th:fragment="head">
     <th:block th:replace="~{modules/head :: moments-head}" />
   </th:block>
-  <th:block th:fragment="content">
-    <div class="moment-back">
-      <a href="/moments" class="back-link">
-        <span class="icon-[ph--arrow-left-bold]"></span>
-        返回瞬间
-      </a>
-    </div>
+  <th:block
+    th:fragment="content"
+    th:with="momentsConfig=${theme.config.plugins?.moments}, content=${moment.spec.content}"
+  >
+    <!--/* ========== 卡片模板详情页（默认） ========== */-->
+    <th:block th:if="${momentsConfig == null or momentsConfig.template == null or momentsConfig.template == 'card'}">
+      <div class="moment-back">
+        <a href="/moments" class="back-link">
+          <span class="icon-[ph--arrow-left-bold]"></span>
+          返回瞬间
+        </a>
+      </div>
 
-    <article th:with="content=${moment.spec.content}" class="moment-detail" style="--delay: 0.1s">
-      <header class="moment-header">
-        <div th:if="${moment.owner != null}" class="author-info">
+      <article class="moment-detail" style="--delay: 0.1s">
+        <header class="moment-header">
+          <div th:if="${moment.owner != null}" class="author-info">
+            <img
+              th:if="${moment.owner.avatar != null}"
+              th:src="${moment.owner.avatar}"
+              th:alt="${moment.owner.displayName}"
+              class="author-avatar"
+              loading="lazy"
+            />
+            <span class="author-name" th:text="${moment.owner.displayName}"></span>
+          </div>
+          <time class="moment-time" th:datetime="${moment.spec.releaseTime}">
+            <span class="icon-[ph--calendar-dots-bold]"></span>
+            <span th:text="${#temporals.format(moment.spec.releaseTime, 'yyyy-MM-dd HH:mm')}"></span>
+          </time>
+        </header>
+
+        <div class="moment-body">
+          <div th:if="${not #strings.isEmpty(content.html)}" class="moment-text" th:utext="${content.html}"></div>
+          <th:block th:replace="~{modules/moment/common :: media}"></th:block>
+        </div>
+
+        <footer class="moment-footer">
+          <div th:if="${not #lists.isEmpty(moment.spec.tags)}" class="moment-tags">
+            <a th:each="tag : ${moment.spec.tags}" th:href="@{/moments(tag=${tag})}" class="moment-tag">
+              <span class="tag-hash">#</span>
+              <span th:text="${tag}"></span>
+            </a>
+          </div>
+          <div class="moment-actions">
+            <th:block th:replace="~{modules/moment/common :: like-button}"></th:block>
+            <a href="#comment" class="action-btn comment" title="查看评论">
+              <span class="icon-[ph--chat-circle-bold]"></span>
+              <span th:text="${moment.stats.approvedComment ?: 0}"></span>
+            </a>
+            <th:block th:replace="~{modules/moment/common :: share-button(url='')}"></th:block>
+          </div>
+        </footer>
+      </article>
+    </th:block>
+
+    <!--/* ========== 列表模板详情页 ========== */-->
+    <th:block th:if="${momentsConfig != null and momentsConfig.template == 'list'}">
+      <div class="moment-back moment-back-simple">
+        <a href="/moments" class="back-link">
+          <span class="icon-[ph--arrow-left-bold]"></span>
+          返回瞬间
+        </a>
+      </div>
+
+      <article class="moment-detail-list" style="--delay: 0.1s">
+        <header class="moment-header">
           <img
-            th:if="${moment.owner.avatar != null}"
+            th:if="${moment.owner != null and moment.owner.avatar != null}"
             th:src="${moment.owner.avatar}"
             th:alt="${moment.owner.displayName}"
             class="author-avatar"
             loading="lazy"
           />
-          <span class="author-name" th:text="${moment.owner.displayName}"></span>
-        </div>
-        <time class="moment-time" th:datetime="${moment.spec.releaseTime}">
-          <span class="icon-[ph--calendar-dots-bold]"></span>
-          <span th:text="${#temporals.format(moment.spec.releaseTime, 'yyyy-MM-dd HH:mm')}"></span>
-        </time>
-      </header>
+          <div th:if="${moment.owner != null}" class="author-name">
+            <span th:text="${moment.owner.displayName}"></span>
+            <time
+              class="moment-time"
+              th:datetime="${moment.spec.releaseTime}"
+              th:text="${#temporals.format(moment.spec.releaseTime, 'yyyy-MM-dd HH:mm')}"
+            ></time>
+          </div>
+        </header>
 
-      <div class="moment-body">
-        <!-- 瞬间文本内容 -->
-        <div th:if="${not #strings.isEmpty(content.html)}" class="moment-text" th:utext="${content.html}"></div>
-        <!-- 瞬间媒体 -->
-        <th:block th:replace="~{modules/moment/common :: media}"></th:block>
-      </div>
+        <div class="moment-body">
+          <div th:if="${not #strings.isEmpty(content.html)}" class="moment-text" th:utext="${content.html}"></div>
+          <th:block th:replace="~{modules/moment/common :: media}"></th:block>
+        </div>
 
-      <footer class="moment-footer">
-        <div th:if="${not #lists.isEmpty(moment.spec.tags)}" class="moment-tags">
-          <a th:each="tag : ${moment.spec.tags}" th:href="@{/moments(tag=${tag})}" class="moment-tag">
-            <span class="tag-hash">#</span>
-            <span th:text="${tag}"></span>
-          </a>
-        </div>
-        <div class="moment-actions">
-          <th:block th:replace="~{modules/moment/common :: like-button}"></th:block>
-          <a href="#comment" class="action-btn comment" title="查看评论">
-            <span class="icon-[ph--chat-circle-bold]"></span>
-            <span th:text="${moment.stats.approvedComment ?: 0}"></span>
-          </a>
-          <th:block th:replace="~{modules/moment/common :: share-button(url='')}"></th:block>
-        </div>
-      </footer>
-    </article>
+        <footer class="moment-footer">
+          <div th:if="${not #lists.isEmpty(moment.spec.tags)}" class="moment-tags">
+            <a th:each="tag : ${moment.spec.tags}" th:href="@{/moments(tag=${tag})}" class="moment-tag">
+              <span class="icon-[ph--tag-bold]"></span>
+              <span th:text="${tag}"></span>
+            </a>
+          </div>
+          <div class="moment-actions">
+            <th:block th:replace="~{modules/moment/common :: like-button}"></th:block>
+            <a href="#comment" class="action-btn comment" title="查看评论">
+              <span class="icon-[ph--chat-circle-bold]"></span>
+              <span th:text="${moment.stats.approvedComment ?: 0}"></span>
+            </a>
+            <th:block th:replace="~{modules/moment/common :: share-button(url='')}"></th:block>
+          </div>
+        </footer>
+      </article>
+    </th:block>
 
     <!-- 评论区 -->
     <th:block

--- a/templates/moments.html
+++ b/templates/moments.html
@@ -6,23 +6,71 @@
   <th:block th:fragment="head">
     <th:block th:replace="~{modules/head :: moments-head}" />
   </th:block>
-  <th:block th:fragment="content">
-    <!-- 瞬间列表标题 -->
-    <th:block th:replace="~{modules/moment/header :: content}" />
-    <!-- 瞬间标签 -->
-    <th:block th:replace="~{modules/moment/tags :: content}" />
+  <th:block th:fragment="content" th:with="momentsConfig=${theme.config.plugins?.moments}">
+    <!--/* ========== 卡片模式（默认） ========== */-->
+    <th:block th:if="${momentsConfig == null or momentsConfig.template == null or momentsConfig.template == 'card'}">
+      <!-- 瞬间列表标题 -->
+      <th:block th:replace="~{modules/moment/header :: content}" />
+      <!-- 瞬间标签 -->
+      <th:block th:replace="~{modules/moment/tags :: content}" />
 
-    <div class="moments-list proper-height">
-      <!-- 瞬间列表 -->
-      <th:block th:replace="~{modules/moment/card :: content}" />
+      <div class="moments-list proper-height">
+        <!-- 瞬间列表 -->
+        <th:block th:replace="~{modules/moment/card :: content}" />
 
-      <div th:if="${#lists.isEmpty(moments.items)}" class="moments-empty">
-        <span class="icon-[ph--shooting-star-bold]"></span>
-        <p>暂无瞬间</p>
+        <div th:if="${#lists.isEmpty(moments.items)}" class="moments-empty">
+          <span class="icon-[ph--shooting-star-bold]"></span>
+          <p>暂无瞬间</p>
+        </div>
+
+        <!-- 分页 -->
+        <th:block th:replace="~{modules/pagination :: pagination(data=${moments})}" />
+      </div>
+    </th:block>
+
+    <!--/* ========== 列表模式 ========== */-->
+    <th:block th:if="${momentsConfig != null and momentsConfig.template == 'list'}">
+      <div
+        class="moments-banner"
+        th:style="${momentsConfig.banner_image != null and momentsConfig.banner_image != ''} ? 'background-image: url(' + ${momentsConfig.banner_image} + ')' : ''"
+      >
+        <div class="moments-banner-content">
+          <h1 class="moments-banner-title" th:text="${momentsConfig.title ?: '瞬间'}">瞬间</h1>
+          <div class="moments-banner-bottom">
+            <p class="moments-banner-desc" th:text="${momentsConfig.banner_desc ?: '记录生活中的点滴瞬间。'}">
+              记录生活中的点滴瞬间。
+            </p>
+            <div class="moments-banner-meta">
+              <span class="moments-banner-count" th:if="${moments.total > 0}">
+                <strong th:text="${moments.total}"></strong> 条瞬间
+              </span>
+              <a href="/moments/rss.xml" class="moments-banner-rss" title="RSS 订阅" target="_blank" rel="noopener">
+                <span class="icon-[ph--rss-simple-bold]"></span>
+              </a>
+            </div>
+          </div>
+        </div>
       </div>
 
-      <!-- 分页 -->
-      <th:block th:replace="~{modules/pagination :: pagination(data=${moments})}" />
-    </div>
+      <!-- 标签筛选栏 -->
+      <div class="moments-list-tags">
+        <th:block th:replace="~{modules/moment/tags :: content}" />
+      </div>
+
+      <div class="page-moments-list proper-height">
+        <div class="moment-list-items">
+          <!-- 瞬间列表项 -->
+          <th:block th:replace="~{modules/moment/list-card :: content}" />
+        </div>
+
+        <div th:if="${#lists.isEmpty(moments.items)}" class="moments-empty">
+          <span class="icon-[ph--shooting-star-bold]"></span>
+          <p>暂无瞬间</p>
+        </div>
+
+        <!-- 分页 -->
+        <th:block th:replace="~{modules/pagination :: pagination(data=${moments})}" />
+      </div>
+    </th:block>
   </th:block>
 </html>


### PR DESCRIPTION
  - 新增瞬间列表模式展示模板，与卡片模式并存
  - 添加列表模式详情页样式
  - 支持通过 settings.yaml 选择模板样式（卡片/列表）

  主要改动
  - settings.yaml: 新增模板选择配置、列表模式 Banner 配置
  - 新增文件:
    - src/styles/moments/_list.scss - 列表模式样式
    - src/styles/moments/_detail-list.scss - 列表详情页样式
    - templates/modules/moment/list-card.html - 列表卡片组件
  - 模板调整:
    - templates/moments.html - 支持两种模板切换
    - templates/moment.html - 详情页支持两种模板
    - src/styles/moments/main.scss - 引入新样式文件