### PR TITLE
feat(docs): 添加启用主题模板的开关配置

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1309,6 +1309,11 @@ spec:
               value: 文档
               placeholder: 文档
             - $formkit: switch
+              name: enable_template
+              label: 启用主题模板
+              help: 开启后使用主题模板，关闭后使用默认模板
+              value: true
+            - $formkit: switch
               name: enable_docs_h1
               label: 在文档内容启用 H1 标题
               help: 开启后文档内容将显示 H1 标题

--- a/templates/doc-catalog.html
+++ b/templates/doc-catalog.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = ${docTree?.spec?.title}, head = ~{::head})}"
+  th:replace="${theme.config.plugins?.docs?.enable_template != false} ? ~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = ${docTree?.spec?.title}, head = ~{::head})} : ~{plugin:plugin-docsme:doc-catalog}"
 >
   <th:block th:fragment="head">
     <th:block th:replace="~{modules/head :: docs-head}" />

--- a/templates/doc.html
+++ b/templates/doc.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = ${docTree?.spec?.title}, head = ~{::head})}"
+  th:replace="${theme.config.plugins?.docs?.enable_template != false} ? ~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = ${docTree?.spec?.title}, head = ~{::head})} : ~{plugin:plugin-docsme:doc}"
 >
   <th:block th:fragment="head">
     <th:block th:replace="~{modules/head :: docs-head}" />

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html
   xmlns:th="https://www.thymeleaf.org"
-  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = (${theme.config.plugins?.docs?.title} ?: '文档'), head = ~{::head})}"
+  th:replace="${theme.config.plugins?.docs?.enable_template != false} ? ~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = (${theme.config.plugins?.docs?.title} ?: '文档'), head = ~{::head})} : ~{plugin:plugin-docsme:docs}"
 >
   <th:block th:fragment="head">
     <th:block th:replace="~{modules/head :: docs-head}" />


### PR DESCRIPTION
```
可在插件适配中关闭使用主题的文档模板。
```