### PR TITLE
fix(friends-list): 修复朋友圈列表在移动端下右侧被截断问题

### DIFF
--- a/src/styles/friends/_list.scss
+++ b/src/styles/friends/_list.scss
@@ -10,7 +10,7 @@
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
 	gap: 0.75rem;
-	padding: 0.5rem $spacing-lg $spacing-lg;
+	padding: 0.5rem $spacing-sm $spacing-lg;
 
 	@media (max-width: $breakpoint-mobile) {
 		grid-template-columns: 1fr;


### PR DESCRIPTION
```
none
```