### PR TITLE
feat(homepage-widgets): 添加随机文章组件

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -879,6 +879,8 @@ spec:
                       label: 精选文章
                     - value: "hot-post"
                       label: 热门文章
+                    - value: "random-post"
+                      label: 随机文章
                     - value: "custom"
                       label: 自定义内容
                 - $formkit: text
@@ -894,6 +896,8 @@ spec:
                   rows: 5
         - $formkit: group
           name: featured
+          id: featured
+          key: featured
           label: 精选文章配置
           children:
             - $formkit: text
@@ -908,6 +912,8 @@ spec:
               help: 选择要在首页轮播展示的文章
         - $formkit: group
           name: hot_post
+          id: hot_post
+          key: hot_post
           label: 热门文章配置
           children:
             - $formkit: text
@@ -922,6 +928,25 @@ spec:
               min: 1
               max: 10
               help: 选择要在首页展示的热门文章数量
+        - $formkit: group
+          name: random_post
+          id: random_post
+          key: random_post
+          label: 随机文章配置
+          help: halo 版本需要 >= 2.24.1 才支持（文章数量大于1时是随机的连续文章，完全随机需要等待后续支持）
+          children:
+            - $formkit: text
+              name: title
+              label: 标题
+              placeholder: 默认标题：随机文章
+              value: "随机文章"
+            - $formkit: number
+              name: post_number
+              label: 文章数量
+              value: 5
+              min: 1
+              max: 10
+              help: 选择要在首页展示的随机文章数量
         - $formkit: switch
           name: enable_toolbar
           label: 关闭分类栏

--- a/templates/modules/home-widgets/random-post-widget.html
+++ b/templates/modules/home-widgets/random-post-widget.html
@@ -1,0 +1,26 @@
+<div
+  class="z-slide"
+  th:fragment="random-post"
+  th:if="${site.version != null and site.version.compareTo('2.24.1') >= 0 and theme.config.post.random_post != null and T(java.lang.Integer).parseInt(theme.config.post.random_post.post_number) > 0}"
+>
+  <div
+    th:replace="~{modules/home-widgets/slide-widget-base::header(${theme.config.post.random_post.title ?: '随机文章'})}"
+  ></div>
+
+  <div class="z-slide-body">
+    <div class="slide-list" id="random-post-scroll-container">
+      <th:block
+        th:with="postNumber = ${T(java.lang.Integer).parseInt(theme.config.post.random_post.post_number)},
+                 posts = ${postFinder.random(postNumber)}"
+      >
+        <th:block th:each="post : ${posts}">
+          <div th:replace="~{modules/home-widgets/slide-widget-base::post-item(${post})}"></div>
+        </th:block>
+      </th:block>
+    </div>
+
+    <div th:replace="~{modules/home-widgets/slide-widget-base::footer('random-post-scroll-container')}"></div>
+  </div>
+
+  <div th:replace="~{modules/home-widgets/slide-widget-base::script('random-post-scroll-container')}"></div>
+</div>

--- a/templates/modules/home.html
+++ b/templates/modules/home.html
@@ -10,6 +10,9 @@
         <!-- 热门文章组件 -->
         <section th:case="hot-post" th:insert="~{modules/home-widgets/hot-post-widget :: hot-post}"></section>
 
+        <!-- 随机文章组件 -->
+        <section th:case="random-post" th:insert="~{modules/home-widgets/random-post-widget :: random-post}"></section>
+
         <!-- 自定义组件 -->
         <section
           th:case="custom"


### PR DESCRIPTION
### 说明
- 重要：支持向下兼容，可以放心升级
- halo 版本需要 >= 2.24.1 才支持随机组件
- 文章数量大于 1 时是随机的连续文章，完全随机需要等待后续支持，https://github.com/halo-dev/halo/issues/9929

### 预览
<img width="2463" height="1289" alt="image" src="https://github.com/user-attachments/assets/7b2d48b4-5de2-4ca1-8627-427e635a25d5" />

### change

```
- 重要：支持向下兼容，可以放心升级
- halo 版本需要 >= 2.24.1 才支持随机组件
- 文章数量大于 1 时是随机的连续文章，完全随机需要等待后续支持
```