### PR TITLE
fix: 修复活跃日历组件因 T(java.util.Collections).emptyList() 被禁止导致白屏的问题

### DIFF
--- a/templates/modules/aside-widgets/activity-calendar-widget.html
+++ b/templates/modules/aside-widgets/activity-calendar-widget.html
@@ -5,7 +5,7 @@
     calendarTitle=${item.calendar_title ?: '活跃日历'},
     activityLimit=${T(java.lang.Integer).parseInt((item.activity_limit ?: 240).toString())},
     postItems=${postFinder.list(1, activityLimit).items},
-    momentItems=${pluginFinder.available('PluginMoments') ? momentFinder.list(1, activityLimit).items : T(java.util.Collections).emptyList()},
+    momentItems=${pluginFinder.available('PluginMoments') ? momentFinder.list(1, activityLimit).items : {}},
     commentItems=${commentFinder.list(null, 1, activityLimit).items}
   "
 >


### PR DESCRIPTION
### 问题描述

在 Halo 2.24 版本中，启用主题 Clarity 的「活跃日历」侧边栏组件后，出现以下问题：

- 侧边栏无法正常加载
- 主页直接白屏 / 无法显示

### 错误日志

Halo 日志中出现的核心错误：

```
Caused by: org.springframework.expression.EvaluationException: 
Access is forbidden for type 'java.util.Collections' in this expression context.
```

### 问题根源定位

在 `modules/aside-widgets/activity-calendar-widget.html` 文件中，第 8 行使用了被 Halo 2.24 禁止的 Java 类调用：

```
momentItems=${pluginFinder.available('PluginMoments') ? momentFinder.list(1, activityLimit).items : T(java.util.Collections).emptyList()},
```

其中 `T(java.util.Collections).emptyList()` 在 Halo 2.24 的安全加固中被禁止，导致模板渲染失败。

### 解决方案

将 `T(java.util.Collections).emptyList()` 替换为 Thymeleaf 原生的空列表字面量 `{}`。

**修改前：**

```
momentItems=${pluginFinder.available('PluginMoments') ? momentFinder.list(1, activityLimit).items : T(java.util.Collections).emptyList()},
```

**修改后：**

```
momentItems=${pluginFinder.available('PluginMoments') ? momentFinder.list(1, activityLimit).items : {}},
```

修改后「活跃日历」组件可正常加载，主页恢复正常。

Closes #167
