### PR TITLE
feat(steam): 最近游玩卡片显示库外游戏标识

### DIFF
--- a/src/styles/steam/_game-card.scss
+++ b/src/styles/steam/_game-card.scss
@@ -25,6 +25,7 @@
 
   // 链接
   &__link {
+    position: relative;
     display: block;
     text-decoration: none;
     color: inherit;
@@ -36,6 +37,20 @@
     aspect-ratio: 460 / 215;
     object-fit: cover;
     display: block;
+  }
+
+  // 库外标识角标（叠加在封面右上角）
+  &__library-badge {
+    position: absolute;
+    top: $spacing-sm;
+    right: $spacing-sm;
+    padding: 2px $spacing-sm;
+    background: var(--c-primary);
+    color: #fff;
+    border-radius: $radius-md;
+    font-size: $font-size-xs;
+    font-weight: 600;
+    line-height: 1.4;
   }
 
   // 信息区域

--- a/templates/modules/steam/recent-games.html
+++ b/templates/modules/steam/recent-games.html
@@ -20,6 +20,12 @@
           class="steam-game-card__link"
         >
           <img class="steam-game-card__img" th:src="${game.headerImageUrl}" th:alt="${game.name}" loading="lazy" />
+          <span
+            class="steam-game-card__library-badge"
+            th:if="${game.inLibrary != null and !game.inLibrary}"
+            title="该游戏不在你的 Steam 游戏库中"
+            >库外</span
+          >
           <div class="steam-game-card__info">
             <div class="steam-game-card__name" th:text="${game.name}">Game</div>
             <div class="steam-game-card__meta">
@@ -39,6 +45,12 @@
         </a>
         <div th:unless="${enableGameLink}" class="steam-game-card__link">
           <img class="steam-game-card__img" th:src="${game.headerImageUrl}" th:alt="${game.name}" loading="lazy" />
+          <span
+            class="steam-game-card__library-badge"
+            th:if="${game.inLibrary != null and !game.inLibrary}"
+            title="该游戏不在你的 Steam 游戏库中"
+            >库外</span
+          >
           <div class="steam-game-card__info">
             <div class="steam-game-card__name" th:text="${game.name}">Game</div>
             <div class="steam-game-card__meta">


### PR DESCRIPTION
不在当前 Steam 游戏库中的最近游玩游戏（家庭共享/免费试玩等）在封面右上角显示「库外」角标，对接 halo-plugin-steam v0.4.0 的 inLibrary 字段。

需 halo-plugin-steam >= v0.4.0