### PR TITLE
feat(friends): 朋友圈改用链接插件 linkFeedFinder 实现

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1336,6 +1336,12 @@ spec:
               label: 页面标题
               value: 朋友圈
               placeholder: 朋友圈
+            - $formkit: number
+              name: feed_limit
+              label: 每次加载条数
+              value: 30
+              validation: "required|number|min:1|max:100"
+              help: 卡片 / 列表模式均生效；首屏及每次「加载更多」获取的动态条数，上限 100（链接插件单次查询上限）
             - $formkit: text
               if: "$get(friends_template).value === 'list'"
               name: banner_desc
@@ -1350,6 +1356,12 @@ spec:
               accepts:
                 - "image/*"
               help: Banner 背景图片，目前仅列表模式生效
+            - $formkit: switch
+              if: "$get(friends_template).value === 'list'"
+              name: enable_random
+              label: 启用随机阅读
+              value: true
+              help: 仅列表模式支持；开启后在朋友圈页显示「随机阅读」入口
         - $formkit: group
           name: docs
           label: 文档插件

--- a/src/pages/page-friends.ts
+++ b/src/pages/page-friends.ts
@@ -1,0 +1,345 @@
+/**
+ * 朋友圈页面（新版）独立入口
+ * 用于单页自定义模板 page_friends.html，数据来源：链接插件 plugin-links 的 linkFeedFinder。
+ * 浏览方式：首屏 SSR + 游标「加载更多」（匿名 REST /linkfeeds 增量追加），并提供随机阅读。
+ * JS 逻辑与旧版 friends.ts 完全独立；样式复用 friends.css（由 page-friends-head 加载）。
+ */
+
+const FEED_API = "/apis/api.link.halo.run/v1alpha1/linkfeeds";
+
+interface FeedItem {
+  url?: string;
+  title?: string;
+  summary?: string;
+  author?: string;
+  authorUrl?: string;
+  authorLogo?: string;
+  publishedAt?: string;
+}
+
+interface FeedPage {
+  items?: FeedItem[];
+  nextBeforePublishedAt?: string | null;
+  nextBeforeId?: string | null;
+  hasNext?: boolean;
+}
+
+interface ArticleData {
+  author: string;
+  title: string;
+  date: string;
+  logo: string;
+  link: string;
+}
+
+type Mode = "card" | "list";
+
+/** 读取模板注入的配置 */
+function getConfig(): { feedLimit: number; enableRandom: boolean } {
+  const cfg = (window as unknown as { friendsPageConfig?: Record<string, unknown> }).friendsPageConfig || {};
+  const n = parseInt(String(cfg.feedLimit), 10);
+  return {
+    feedLimit: Number.isFinite(n) && n > 0 ? Math.min(n, 100) : 30,
+    enableRandom: cfg.enableRandom !== false,
+  };
+}
+
+/** 当前展示模式：列表容器是 .fcircle-articles 则为列表模式，否则卡片模式 */
+function getMode(): Mode {
+  const list = document.getElementById("friends-list");
+  return list && list.classList.contains("fcircle-articles") ? "list" : "card";
+}
+
+/** 仅允许 http(s) 链接，避免 javascript: 等注入 */
+function safeUrl(url?: string): string {
+  return url && /^https?:\/\//i.test(url) ? url : "#";
+}
+
+/** 格式化发布时间：卡片模式 MM-dd，列表模式 yyyy-MM-dd */
+function formatDate(iso: string | undefined, mode: Mode): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return mode === "list" ? `${y}-${m}-${day}` : `${m}-${day}`;
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(tag: K, className?: string): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  return node;
+}
+
+/** 渲染卡片模式条目（结构与 page_friends.html 的 .friend-card 一致） */
+function renderCardItem(item: FeedItem, index: number): HTMLElement {
+  const article = el("article", "friend-card");
+  article.style.setProperty("--delay", `${index * 0.03}s`);
+
+  const header = el("header", "friend-header");
+  const authorInfo = el("a", "author-info");
+  authorInfo.href = safeUrl(item.authorUrl);
+  authorInfo.target = "_blank";
+  authorInfo.rel = "noopener";
+  if (item.authorLogo) {
+    const img = el("img", "author-avatar");
+    img.loading = "lazy";
+    img.src = item.authorLogo;
+    img.alt = item.author || "";
+    authorInfo.appendChild(img);
+  } else {
+    const ph = el("span", "author-avatar-placeholder");
+    ph.appendChild(el("span", "icon-[ph--user-bold]"));
+    authorInfo.appendChild(ph);
+  }
+  const name = el("span", "author-name");
+  name.textContent = item.author || "";
+  authorInfo.appendChild(name);
+  header.appendChild(authorInfo);
+
+  const dateStr = formatDate(item.publishedAt, "card");
+  if (dateStr) {
+    const time = el("time", "friend-time");
+    if (item.publishedAt) time.dateTime = item.publishedAt;
+    time.textContent = dateStr;
+    header.appendChild(time);
+  }
+  article.appendChild(header);
+
+  const content = el("a", "friend-content");
+  content.href = safeUrl(item.url);
+  content.target = "_blank";
+  content.rel = "noopener";
+  const title = el("h2", "friend-title");
+  title.textContent = item.title || "";
+  content.appendChild(title);
+  if (item.summary) {
+    const desc = el("p", "friend-desc");
+    desc.textContent = item.summary;
+    content.appendChild(desc);
+  }
+  article.appendChild(content);
+
+  const footer = el("footer", "friend-footer");
+  const more = el("a", "read-more");
+  more.href = safeUrl(item.url);
+  more.target = "_blank";
+  more.rel = "noopener";
+  const moreText = el("span");
+  moreText.textContent = "阅读原文";
+  more.append(moreText, el("span", "icon-[ph--arrow-up-right-bold]"));
+  footer.appendChild(more);
+  article.appendChild(footer);
+
+  return article;
+}
+
+/** 渲染列表模式条目（结构与 page_friends.html 的 .fcircle-item 一致） */
+function renderListItem(item: FeedItem, index: number): HTMLElement {
+  const wrap = el("div", "fcircle-item");
+  wrap.style.setProperty("--delay", `${index * 0.03}s`);
+
+  if (item.authorLogo) {
+    const imgLink = el("a", "fcircle-item-image");
+    imgLink.href = safeUrl(item.authorUrl);
+    imgLink.target = "_blank";
+    imgLink.rel = "noopener";
+    const img = el("img");
+    img.loading = "lazy";
+    img.src = item.authorLogo;
+    img.alt = item.author || "";
+    imgLink.appendChild(img);
+    wrap.appendChild(imgLink);
+  } else {
+    const ph = el("a", "fcircle-avatar-placeholder");
+    ph.href = safeUrl(item.authorUrl);
+    ph.target = "_blank";
+    ph.rel = "noopener";
+    ph.appendChild(el("span", "icon-[ph--user-bold]"));
+    wrap.appendChild(ph);
+  }
+
+  const container = el("a", "fcircle-item-container gradient-card");
+  container.href = safeUrl(item.url);
+  container.target = "_blank";
+  container.rel = "noopener";
+  const head = el("div", "fcircle-item-header");
+  const author = el("span", "fcircle-item-author");
+  author.textContent = item.author || "";
+  const title = el("span", "fcircle-item-title");
+  title.textContent = item.title || "";
+  head.append(author, title);
+  const dateStr = formatDate(item.publishedAt, "list");
+  if (dateStr) {
+    const time = el("time", "fcircle-item-date");
+    if (item.publishedAt) time.dateTime = item.publishedAt;
+    time.textContent = dateStr;
+    head.appendChild(time);
+  }
+  container.appendChild(head);
+  if (item.summary) {
+    const desc = el("span", "fcircle-item-desc");
+    desc.textContent = item.summary;
+    container.appendChild(desc);
+  }
+  wrap.appendChild(container);
+  return wrap;
+}
+
+function renderItem(item: FeedItem, mode: Mode, index: number): HTMLElement {
+  return mode === "list" ? renderListItem(item, index) : renderCardItem(item, index);
+}
+
+/** 更新「已加载 N 篇」统计（#friends-count），N = 当前已渲染条目数 */
+function updateCount(listEl: HTMLElement) {
+  const countEl = document.getElementById("friends-count");
+  if (!countEl) return;
+  countEl.textContent = String(listEl.querySelectorAll(".friend-card, .fcircle-item").length);
+}
+
+/**
+ * 游标「加载更多」：fetch 匿名 REST，按 nextBeforePublishedAt + nextBeforeId 继续取，渲染追加
+ */
+async function loadMore(btn: HTMLButtonElement, listEl: HTMLElement, mode: Mode, limit: number) {
+  if (btn.dataset.loading === "1") return;
+
+  const textEl = btn.querySelector<HTMLElement>(".friends-load-more-text");
+  const original = textEl?.textContent || "加载更多";
+  btn.dataset.loading = "1";
+  btn.disabled = true;
+  if (textEl) textEl.textContent = "加载中…";
+
+  try {
+    const params = new URLSearchParams();
+    params.set("limit", String(limit));
+    if (btn.dataset.beforePublishedAt) params.set("beforePublishedAt", btn.dataset.beforePublishedAt);
+    if (btn.dataset.beforeId) params.set("beforeId", btn.dataset.beforeId);
+
+    const res = await fetch(`${FEED_API}?${params.toString()}`, { headers: { Accept: "application/json" } });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const page = (await res.json()) as FeedPage;
+    const items = Array.isArray(page.items) ? page.items : [];
+
+    const startIndex = listEl.children.length;
+    const fragment = document.createDocumentFragment();
+    items.forEach((it, i) => fragment.appendChild(renderItem(it, mode, startIndex + i)));
+    listEl.appendChild(fragment);
+    updateCount(listEl);
+
+    if (page.hasNext && (page.nextBeforePublishedAt || page.nextBeforeId)) {
+      btn.dataset.beforePublishedAt = page.nextBeforePublishedAt || "";
+      btn.dataset.beforeId = page.nextBeforeId || "";
+      btn.dataset.loading = "";
+      btn.disabled = false;
+      if (textEl) textEl.textContent = original;
+    } else {
+      // 没有更多了，移除按钮
+      (btn.closest(".friends-load-more") || btn).remove();
+    }
+  } catch {
+    btn.dataset.loading = "";
+    btn.disabled = false;
+    if (textEl) textEl.textContent = "加载失败，点击重试";
+  }
+}
+
+/** 从条目 DOM 提取文章数据（随机用，兼容两种模式） */
+function extractData(item: HTMLElement): ArticleData {
+  if (item.classList.contains("friend-card")) {
+    const link = item.querySelector<HTMLAnchorElement>(".friend-content");
+    return {
+      author: item.querySelector(".author-name")?.textContent?.trim() || "",
+      title: item.querySelector(".friend-title")?.textContent?.trim() || "",
+      date: item.querySelector(".friend-time")?.textContent?.trim() || "",
+      logo: item.querySelector<HTMLImageElement>(".author-avatar")?.src || "",
+      link: link?.href || "",
+    };
+  }
+  const container = item.querySelector<HTMLAnchorElement>(".fcircle-item-container");
+  return {
+    author: item.querySelector(".fcircle-item-author")?.textContent?.trim() || "",
+    title: item.querySelector(".fcircle-item-title")?.textContent?.trim() || "",
+    date: item.querySelector(".fcircle-item-date")?.textContent?.trim() || "",
+    logo: item.querySelector<HTMLImageElement>(".fcircle-item-image img")?.src || "",
+    link: container?.href || "",
+  };
+}
+
+/**
+ * 随机阅读：从当前已渲染（含已「加载更多」的）全部条目中随机抽取
+ */
+function initRandomArticle(enableRandom: boolean) {
+  const randomWrapper = document.getElementById("fcircle-random");
+  if (!randomWrapper) return;
+
+  const randomCard = randomWrapper.querySelector<HTMLAnchorElement>(".fcircle-random-card");
+  const refreshBtn = randomWrapper.querySelector<HTMLButtonElement>(".fcircle-random-refresh");
+  if (!randomCard || !refreshBtn) return;
+
+  const collect = (): ArticleData[] => {
+    const list = document.getElementById("friends-list");
+    if (!list) return [];
+    return Array.from(list.querySelectorAll<HTMLElement>(".friend-card, .fcircle-item"))
+      .map(extractData)
+      .filter((d) => d.link && d.link !== "#");
+  };
+
+  if (!enableRandom || collect().length === 0) {
+    randomWrapper.style.display = "none";
+    return;
+  }
+
+  const renderRandomCard = (data: ArticleData) => {
+    randomCard.innerHTML = "";
+    const author = el("span", "fcircle-random-author");
+    author.textContent = data.author;
+    const title = el("span", "fcircle-random-title-inner");
+    title.textContent = data.title;
+    randomCard.append(author, title);
+    if (data.date) {
+      const time = el("time", "fcircle-random-date");
+      time.textContent = data.date;
+      randomCard.append(time);
+    }
+    randomCard.href = data.link;
+  };
+
+  const showRandom = () => {
+    const data = collect();
+    if (data.length === 0) return;
+    renderRandomCard(data[Math.floor(Math.random() * data.length)]);
+    randomWrapper.style.display = "flex";
+  };
+
+  refreshBtn.onclick = () => {
+    refreshBtn.classList.add("is-spinning");
+    showRandom();
+    setTimeout(() => refreshBtn.classList.remove("is-spinning"), 300);
+  };
+
+  showRandom();
+}
+
+function initFriendsPage() {
+  const listEl = document.getElementById("friends-list");
+  if (!listEl) return;
+
+  const { feedLimit, enableRandom } = getConfig();
+  const mode = getMode();
+
+  updateCount(listEl);
+
+  const btn = document.getElementById("friends-load-more-btn") as HTMLButtonElement | null;
+  if (btn && btn.dataset.bound !== "1") {
+    btn.dataset.bound = "1";
+    btn.addEventListener("click", () => loadMore(btn, listEl, mode, feedLimit));
+  }
+
+  initRandomArticle(enableRandom);
+}
+
+document.addEventListener("DOMContentLoaded", initFriendsPage);
+
+// 支持 Swup 页面切换后的重新初始化
+window.addEventListener("swup:success", initFriendsPage);

--- a/src/styles/friends/_load-more.scss
+++ b/src/styles/friends/_load-more.scss
@@ -1,0 +1,63 @@
+// ========================================
+// 朋友圈「加载更多」按钮 (Friends Load More)
+// 极简文字链接：无边框无底色，hover 变主色 + 下划线滑入。
+// 卡片 / 列表两模式共用，居中、克制、不抢戏。
+// ========================================
+
+@use 'variables' as *;
+@use 'mixins' as *;
+
+.friends-load-more {
+	@include flex(row, center, center);
+	padding: $spacing-lg 0 $spacing-xl;
+}
+
+.friends-load-more-btn {
+	position: relative;
+	@include flex(row, center, center, $spacing-xs);
+	padding: 0.4rem 0.6rem;
+	border: none;
+	background: none;
+	color: var(--c-text-2);
+	font-size: $font-size-md;
+	font-weight: 500;
+	cursor: pointer;
+	transition: color $transition-normal $easing-default;
+
+	// hover 下划线（从中间滑入）
+	&::after {
+		content: "";
+		position: absolute;
+		left: 0.6rem;
+		right: 0.6rem;
+		bottom: 0.15rem;
+		height: 1px;
+		background: currentColor;
+		transform: scaleX(0);
+		transition: transform $transition-normal $easing-default;
+	}
+
+	&:hover:not(:disabled) {
+		color: var(--c-primary);
+
+		&::after {
+			transform: scaleX(1);
+		}
+	}
+
+	&:disabled {
+		opacity: 0.55;
+		cursor: default;
+	}
+}
+
+// ---- 响应式 ----
+@media (max-width: $breakpoint-mobile) {
+	.friends-load-more {
+		padding: $spacing-md 0 $spacing-lg;
+	}
+
+	.friends-load-more-btn {
+		font-size: $font-size-sm;
+	}
+}

--- a/src/styles/friends/main.scss
+++ b/src/styles/friends/main.scss
@@ -13,3 +13,4 @@
 @use 'empty';
 @use 'fcircle';
 @use 'pagination';
+@use 'load-more';

--- a/templates/modules/head.html
+++ b/templates/modules/head.html
@@ -55,6 +55,19 @@
   ></script>
 </th:block>
 
+<th:block th:fragment="page-friends-head">
+  <link
+    rel="stylesheet"
+    data-swup-conditional="page-friends"
+    th:href="@{/assets/dist/friends.css?v={version}(version=${theme.spec.version})}"
+  />
+  <script
+    type="module"
+    data-swup-conditional="page-friends"
+    th:src="@{/assets/dist/page-friends.js?v={version}(version=${theme.spec.version})}"
+  ></script>
+</th:block>
+
 <th:block th:fragment="bangumis-head">
   <link
     rel="stylesheet"

--- a/templates/page_friends.html
+++ b/templates/page_friends.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html
+  xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = ${theme.config.plugins?.friends?.title ?: '朋友圈'}, head = ~{::head})}"
+>
+  <th:block th:fragment="head">
+    <th:block th:replace="~{modules/head :: page-friends-head}" />
+  </th:block>
+  <th:block
+    th:fragment="content"
+    th:with="friendsConfig=${theme.config.plugins?.friends},
+             linksAvailable=${pluginFinder.available('PluginLinks')},
+             feedLimit=${friendsConfig?.feed_limit != null ? T(java.lang.Integer).parseInt(friendsConfig.feed_limit + '') : 30},
+             linkFeeds=${linksAvailable ? linkFeedFinder.list({limit: feedLimit}) : null},
+             enableRandom=${friendsConfig == null or friendsConfig.enable_random != false}"
+  >
+    <!--/* ========== 未安装链接插件 ========== */-->
+    <th:block th:unless="${linksAvailable}">
+      <div class="page-header">
+        <div class="page-title">
+          <span class="icon-[ph--rss-bold]"></span>
+          <h1 class="text-creative" th:text="${friendsConfig?.title ?: '朋友圈'}">朋友圈</h1>
+        </div>
+      </div>
+      <div class="friends-empty">
+        <span class="icon-[ph--plugs-bold]"></span>
+        <p>朋友圈需要链接插件支持</p>
+        <span class="empty-hint">
+          请安装并启用链接插件（plugin-links ≥ 2.2.0），在其设置中开启「公开 RSS 订阅动态」，并为友链配置 RSS 地址
+        </span>
+      </div>
+    </th:block>
+
+    <!--/* ========== 卡片模式（默认） ========== */-->
+    <th:block
+      th:if="${linksAvailable and (friendsConfig == null or friendsConfig.template == null or friendsConfig.template == 'card')}"
+    >
+      <div class="page-header">
+        <div class="page-title">
+          <span class="icon-[ph--rss-bold]"></span>
+          <h1 class="text-creative" th:text="${friendsConfig?.title ?: '朋友圈'}">朋友圈</h1>
+        </div>
+        <div class="page-actions">
+          <span class="page-count" th:if="${linkFeeds != null and !#lists.isEmpty(linkFeeds.items)}">
+            已加载 <strong id="friends-count" th:text="${#lists.size(linkFeeds.items)}">0</strong> 篇
+          </span>
+          <a th:if="${theme.config.links?.enable_submit}" href="/links#add" class="page-action-link" title="申请友链">
+            <span class="icon-[ph--handshake-bold]"></span>
+            申请友链
+          </a>
+        </div>
+      </div>
+
+      <div class="friends-list proper-height" id="friends-list">
+        <article
+          th:each="linkFeed,iterStat : ${linkFeeds?.items}"
+          class="friend-card"
+          th:style="'--delay: ' + ${iterStat.index * 0.03} + 's'"
+        >
+          <header class="friend-header">
+            <a th:href="${linkFeed.authorUrl}" target="_blank" rel="noopener" class="author-info">
+              <img
+                th:if="${linkFeed.authorLogo != null and linkFeed.authorLogo != ''}"
+                th:src="${linkFeed.authorLogo}"
+                th:alt="${linkFeed.author}"
+                class="author-avatar"
+                loading="lazy"
+              />
+              <span
+                th:unless="${linkFeed.authorLogo != null and linkFeed.authorLogo != ''}"
+                class="author-avatar-placeholder"
+              >
+                <span class="icon-[ph--user-bold]"></span>
+              </span>
+              <span class="author-name" th:text="${linkFeed.author}">作者</span>
+            </a>
+            <time
+              th:if="${linkFeed.publishedAt != null}"
+              class="friend-time"
+              th:datetime="${linkFeed.publishedAt}"
+              th:text="${#temporals.format(linkFeed.publishedAt, 'MM-dd')}"
+            ></time>
+          </header>
+
+          <a th:href="${linkFeed.url}" target="_blank" rel="noopener" class="friend-content">
+            <h2 class="friend-title" th:text="${linkFeed.title}">文章标题</h2>
+            <p
+              th:if="${linkFeed.summary != null and linkFeed.summary != ''}"
+              class="friend-desc"
+              th:text="${linkFeed.summary}"
+            ></p>
+          </a>
+
+          <footer class="friend-footer">
+            <a th:href="${linkFeed.url}" target="_blank" rel="noopener" class="read-more">
+              <span>阅读原文</span>
+              <span class="icon-[ph--arrow-up-right-bold]"></span>
+            </a>
+          </footer>
+        </article>
+
+        <div th:if="${linkFeeds == null or #lists.isEmpty(linkFeeds.items)}" class="friends-empty">
+          <span class="icon-[ph--rss-bold]"></span>
+          <p>暂无订阅内容</p>
+          <span class="empty-hint">请在链接插件中为友链配置 RSS，并开启「公开 RSS 订阅动态」</span>
+        </div>
+      </div>
+
+      <div class="friends-load-more" th:if="${linkFeeds != null and linkFeeds.hasNext}">
+        <button
+          type="button"
+          id="friends-load-more-btn"
+          class="friends-load-more-btn"
+          th:attr="data-before-published-at=${linkFeeds.nextBeforePublishedAt}, data-before-id=${linkFeeds.nextBeforeId}"
+        >
+          <span class="friends-load-more-text">加载更多</span>
+        </button>
+      </div>
+    </th:block>
+
+    <!--/* ========== 列表模式 ========== */-->
+    <th:block th:if="${linksAvailable and friendsConfig != null and friendsConfig.template == 'list'}">
+      <div
+        class="fcircle-banner"
+        th:style="${friendsConfig.banner_image != null and friendsConfig.banner_image != ''} ? 'background-image: url(' + ${friendsConfig.banner_image} + ')' : ''"
+      >
+        <div class="fcircle-banner-content">
+          <h1 class="fcircle-banner-title" th:text="${friendsConfig.title ?: '朋友圈'}">朋友圈</h1>
+          <div class="fcircle-banner-bottom">
+            <p class="fcircle-banner-desc" th:text="${friendsConfig.banner_desc ?: '发现更多有趣的博主。'}">
+              发现更多有趣的博主。
+            </p>
+            <span class="fcircle-banner-count" th:if="${linkFeeds != null and !#lists.isEmpty(linkFeeds.items)}">
+              已加载 <strong id="friends-count" th:text="${#lists.size(linkFeeds.items)}">0</strong> 篇
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div class="page-fcircle proper-height">
+        <div
+          th:if="${enableRandom and linkFeeds != null and !#lists.isEmpty(linkFeeds.items)}"
+          class="fcircle-random-wrapper"
+          id="fcircle-random"
+          style="display: none"
+        >
+          <span class="fcircle-random-title">随机阅读</span>
+          <a class="fcircle-random-card" href="#" target="_blank" rel="noopener">
+            <!-- 由 JS 填充 -->
+          </a>
+          <button class="fcircle-random-refresh" title="换一个">
+            <span class="icon-[ph--arrows-clockwise-bold]"></span>
+          </button>
+        </div>
+        <div class="fcircle-articles" id="friends-list">
+          <div
+            th:each="linkFeed,iterStat : ${linkFeeds?.items}"
+            class="fcircle-item"
+            th:style="'--delay: ' + ${iterStat.index * 0.03} + 's'"
+          >
+            <a
+              th:href="${linkFeed.authorUrl}"
+              target="_blank"
+              rel="noopener"
+              class="fcircle-item-image"
+              th:if="${linkFeed.authorLogo != null and linkFeed.authorLogo != ''}"
+            >
+              <img th:src="${linkFeed.authorLogo}" th:alt="${linkFeed.author}" loading="lazy" />
+            </a>
+            <a
+              th:href="${linkFeed.authorUrl}"
+              target="_blank"
+              rel="noopener"
+              th:unless="${linkFeed.authorLogo != null and linkFeed.authorLogo != ''}"
+              class="fcircle-avatar-placeholder"
+            >
+              <span class="icon-[ph--user-bold]"></span>
+            </a>
+            <a th:href="${linkFeed.url}" target="_blank" rel="noopener" class="fcircle-item-container gradient-card">
+              <div class="fcircle-item-header">
+                <span class="fcircle-item-author" th:text="${linkFeed.author}">网站名</span>
+                <span class="fcircle-item-title" th:text="${linkFeed.title}">文章标题</span>
+                <time
+                  th:if="${linkFeed.publishedAt != null}"
+                  class="fcircle-item-date"
+                  th:datetime="${linkFeed.publishedAt}"
+                  th:text="${#temporals.format(linkFeed.publishedAt, 'yyyy-MM-dd')}"
+                ></time>
+              </div>
+              <span
+                th:if="${linkFeed.summary != null and linkFeed.summary != ''}"
+                class="fcircle-item-desc"
+                th:text="${linkFeed.summary}"
+              ></span>
+            </a>
+          </div>
+        </div>
+
+        <div th:if="${linkFeeds == null or #lists.isEmpty(linkFeeds.items)}" class="friends-empty">
+          <span class="icon-[ph--rss-bold]"></span>
+          <p>暂无订阅内容</p>
+          <span class="empty-hint">请在链接插件中为友链配置 RSS，并开启「公开 RSS 订阅动态」</span>
+        </div>
+
+        <div class="friends-load-more" th:if="${linkFeeds != null and linkFeeds.hasNext}">
+          <button
+            type="button"
+            id="friends-load-more-btn"
+            class="friends-load-more-btn"
+            th:attr="data-before-published-at=${linkFeeds.nextBeforePublishedAt}, data-before-id=${linkFeeds.nextBeforeId}"
+          >
+            <span class="friends-load-more-text">加载更多</span>
+          </button>
+        </div>
+      </div>
+    </th:block>
+
+    <script th:inline="javascript">
+      /*<![CDATA[*/
+      window.friendsPageConfig = {
+        feedLimit: /*[[${friendsConfig?.feed_limit ?: 30}]]*/ 30,
+        enableRandom: /*[[${friendsConfig == null or friendsConfig.enable_random != false}]]*/ true,
+      };
+      /*]]>*/
+    </script>
+  </th:block>
+</html>

--- a/theme.yaml
+++ b/theme.yaml
@@ -16,6 +16,11 @@ spec:
   configMapName: "theme-clarity-configMap"
   version: "1.6.2"
   requires: ">=2.22.0"
+  customTemplates:
+    page:
+      - name: 朋友圈
+        description: 友链 RSS 动态聚合，需安装链接插件（plugin-links ≥2.2.0）并开启「公开 RSS 订阅动态」
+        file: page_friends.html
   license:
     - name: "GPL-3.0"
       url: "https://github.com/acanyo/theme-clarity/blob/main/LICENSE"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,7 @@ export default ({ mode }: { mode: string }) => {
     moments: path.resolve(__dirname, "src/pages/moments.ts"),
     links: path.resolve(__dirname, "src/pages/links.ts"),
     friends: path.resolve(__dirname, "src/pages/friends.ts"),
+    "page-friends": path.resolve(__dirname, "src/pages/page-friends.ts"),
     bangumis: path.resolve(__dirname, "src/styles/bangumis/main.scss"),
     photos: path.resolve(__dirname, "src/styles/photos/main.scss"),
     equipments: path.resolve(__dirname, "src/styles/equipments/main.scss"),


### PR DESCRIPTION
- 新增单页自定义模板 page_friends.html，用 linkFeedFinder 聚合友链 RSS 动态
- 浏览采用游标「加载更多」，随机阅读仅列表模式生效
- 新增独立入口 src/pages/page-friends.ts，旧版 friends.ts 保留不修改
- settings 朋友圈组新增 feed_limit / enable_random，feed_limit 置于通用区
- 保留旧版 friends.html，与新方案并存（共用 friends 配置组）