### PR TITLE
feat(steam): 标识不可用（已下架）游戏

### DIFF
--- a/src/styles/steam/_game-card.scss
+++ b/src/styles/steam/_game-card.scss
@@ -53,6 +53,21 @@
     line-height: 1.4;
   }
 
+  // 不可用标识角标（叠加在封面左上角，灰色调；与库外角标左右错开避免重叠）
+  &__delisted-badge {
+    position: absolute;
+    top: $spacing-sm;
+    left: $spacing-sm;
+    padding: 2px $spacing-sm;
+    background: rgba(60, 60, 60, 0.88);
+    color: #d4d4d4;
+    border: 1px solid rgba(200, 200, 200, 0.4);
+    border-radius: $radius-md;
+    font-size: $font-size-xs;
+    font-weight: 600;
+    line-height: 1.4;
+  }
+
   // 信息区域
   &__info {
     padding: $spacing-md;

--- a/templates/modules/steam/games-grid.html
+++ b/templates/modules/steam/games-grid.html
@@ -24,6 +24,12 @@
             class="steam-game-card__link"
           >
             <img class="steam-game-card__img" th:src="${game.headerImageUrl}" th:alt="${game.name}" loading="lazy" />
+            <span
+              class="steam-game-card__delisted-badge"
+              th:if="${game.delisted}"
+              title="该游戏已从 Steam 商店下架或暂不可用"
+              >不可用</span
+            >
             <div class="steam-game-card__info">
               <div class="steam-game-card__name" th:text="${game.name}">Game</div>
               <div class="steam-game-card__meta">
@@ -38,6 +44,12 @@
           </a>
           <div th:unless="${enableGameLink}" class="steam-game-card__link">
             <img class="steam-game-card__img" th:src="${game.headerImageUrl}" th:alt="${game.name}" loading="lazy" />
+            <span
+              class="steam-game-card__delisted-badge"
+              th:if="${game.delisted}"
+              title="该游戏已从 Steam 商店下架或暂不可用"
+              >不可用</span
+            >
             <div class="steam-game-card__info">
               <div class="steam-game-card__name" th:text="${game.name}">Game</div>
               <div class="steam-game-card__meta">

--- a/templates/modules/steam/recent-games.html
+++ b/templates/modules/steam/recent-games.html
@@ -26,6 +26,12 @@
             title="该游戏不在你的 Steam 游戏库中"
             >库外</span
           >
+          <span
+            class="steam-game-card__delisted-badge"
+            th:if="${game.delisted}"
+            title="该游戏已从 Steam 商店下架或暂不可用"
+            >不可用</span
+          >
           <div class="steam-game-card__info">
             <div class="steam-game-card__name" th:text="${game.name}">Game</div>
             <div class="steam-game-card__meta">
@@ -50,6 +56,12 @@
             th:if="${game.inLibrary != null and !game.inLibrary}"
             title="该游戏不在你的 Steam 游戏库中"
             >库外</span
+          >
+          <span
+            class="steam-game-card__delisted-badge"
+            th:if="${game.delisted}"
+            title="该游戏已从 Steam 商店下架或暂不可用"
+            >不可用</span
           >
           <div class="steam-game-card__info">
             <div class="steam-game-card__name" th:text="${game.name}">Game</div>


### PR DESCRIPTION
适配 halo-plugin-steam v1.0.0 新增的 OwnedGame.delisted 字段：

- recent-games.html / games-grid.html 各分支补「不可用」角标 (th:if=delisted)
- _game-card.scss 新增 delisted-badge（左上灰色，与右上「库外」角标错开避免重叠）