### PR TITLE
style: 优化文章标题溢出显示与tooltip补充

### DIFF
--- a/src/styles/scss/components/_post-card.scss
+++ b/src/styles/scss/components/_post-card.scss
@@ -60,6 +60,15 @@ $breakpoint-phone: 528px !default;
 .article-title {
 	font-size: 1.2em;
 	color: var(--c-text);
+	line-height: 1.4;
+
+	> a {
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 	
 	.pinned-post {
 		display: inline-block;

--- a/src/styles/scss/components/_slide.scss
+++ b/src/styles/scss/components/_slide.scss
@@ -117,6 +117,13 @@
 
 			> .title {
 				text-wrap: balance;
+				max-width: 100%;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				display: -webkit-box;
+				-webkit-line-clamp: 3;
+				-webkit-box-orient: vertical;
+				line-height: 1.3;
 			}
 
 			> .desc {

--- a/src/styles/scss/components/archives/_archive-list.scss
+++ b/src/styles/scss/components/archives/_archive-list.scss
@@ -55,6 +55,12 @@
 // 文章标题
 .article-title {
 	color: var(--c-text);
+	display: inline-block;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	line-height: 1.4;
 }
 
 // 文章链接卡片

--- a/src/styles/scss/components/post/_surround.scss
+++ b/src/styles/scss/components/post/_surround.scss
@@ -38,10 +38,18 @@
 		overflow: hidden;
 
 		> .title {
-			display: block;
+			display: -webkit-box;
+			-webkit-line-clamp: 2;
+			-webkit-box-orient: vertical;
 			overflow: hidden;
 			text-overflow: ellipsis;
-			white-space: nowrap;
+			line-height: 1.4;
+			margin-bottom: 0.25rem;
+
+			@media (max-width: 640px) {
+				-webkit-line-clamp: 3;
+				line-height: 1.3;
+			}
 		}
 
 		> .date {

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -42,12 +42,8 @@
                 th:style="'--delay: ' + ${postStat.index * 0.03} + 's'"
               >
                 <time th:text="${#temporals.format(post.spec.publishTime, 'MM/dd')}"></time>
-                <a
-                  th:href="${post.status.permalink}"
-                  class="article-link gradient-card"
-                  th:title="${post.status.excerpt}"
-                >
-                  <span class="article-title" th:text="${post.spec.title}"></span>
+                <a th:href="${post.status.permalink}" class="article-link gradient-card">
+                  <span class="article-title" th:text="${post.spec.title}" th:title="${post.spec.title}"></span>
                   <img
                     th:if="${post.spec.cover}"
                     th:src="${post.spec.cover}"

--- a/templates/author.html
+++ b/templates/author.html
@@ -51,8 +51,8 @@
           th:style="'--delay: ' + ${iterStat.index * 0.03} + 's'"
         >
           <time th:text="${#temporals.format(post.spec.publishTime, 'MM/dd')}"></time>
-          <a th:href="${post.status.permalink}" class="article-link gradient-card" th:title="${post.status.excerpt}">
-            <span class="article-title" th:text="${post.spec.title}"></span>
+          <a th:href="${post.status.permalink}" class="article-link gradient-card">
+            <span class="article-title" th:text="${post.spec.title}" th:title="${post.spec.title}"></span>
             <th:block th:if="${post.spec.pinned}" th:insert="~{modules/common/pinned-icon :: pinned-icon}" />
             <img
               th:if="${post.spec.cover}"

--- a/templates/modules/archive-layout/new.html
+++ b/templates/modules/archive-layout/new.html
@@ -18,8 +18,8 @@
         th:style="'--delay: ' + ${postStat.index * 0.03} + 's'"
       >
         <time th:text="${#temporals.format(post.spec.publishTime, 'MM/dd')}"></time>
-        <a th:href="${post.status.permalink}" class="article-link gradient-card" th:title="${post.status.excerpt}">
-          <span class="article-title" th:text="${post.spec.title}"></span>
+        <a th:href="${post.status.permalink}" class="article-link gradient-card">
+          <span class="article-title" th:text="${post.spec.title}" th:title="${post.spec.title}"></span>
           <th:block th:if="${post.spec.pinned}" th:insert="~{modules/common/pinned-icon :: pinned-icon}" />
           <img
             th:if="${post.spec.cover}"

--- a/templates/modules/home-widgets/slide-widget-base.html
+++ b/templates/modules/home-widgets/slide-widget-base.html
@@ -24,7 +24,7 @@
     </div>
 
     <div class="info">
-      <div class="title text-creative" th:text="${post.spec.title}"></div>
+      <div class="title text-creative" th:text="${post.spec.title}" th:title="${post.spec.title}"></div>
       <div class="desc" th:if="${post.spec.publishTime}">
         <span class="icon-[ph--calendar-dots-bold]"></span>
         <span th:text="${#temporals.format(post.spec.publishTime, 'yyyy-MM-dd')}"></span>

--- a/templates/modules/post-card.html
+++ b/templates/modules/post-card.html
@@ -13,7 +13,7 @@
 
   <article>
     <h2 class="article-title text-creative">
-      <a th:href="${post.status.permalink}" th:text="${post.spec.title}"></a>
+      <a th:href="${post.status.permalink}" th:text="${post.spec.title}" th:title="${post.spec.title}"></a>
     </h2>
 
     <p

--- a/templates/modules/post-list.html
+++ b/templates/modules/post-list.html
@@ -25,7 +25,7 @@
 
         <div class="article-body">
           <h2 class="article-title text-creative">
-            <a th:href="${post.status.permalink}" th:text="${post.spec.title}"></a>
+            <a th:href="${post.status.permalink}" th:text="${post.spec.title}" th:title="${post.spec.title}"></a>
             <th:block th:if="${post.spec.pinned}" th:insert="~{modules/common/pinned-icon :: pinned-icon}" />
           </h2>
 

--- a/templates/modules/post-slide.html
+++ b/templates/modules/post-slide.html
@@ -38,7 +38,7 @@
             </div>
 
             <div class="info">
-              <div class="title text-creative" th:text="${post.spec.title}"></div>
+              <div class="title text-creative" th:text="${post.spec.title}" th:title="${post.spec.title}"></div>
               <div class="desc" th:if="${post.spec.publishTime}">
                 <span class="icon-[ph--calendar-dots-bold]"></span>
                 <span th:text="${#temporals.format(post.spec.publishTime, 'yyyy-MM-dd')}"></span>

--- a/templates/modules/post/cursor-post.html
+++ b/templates/modules/post/cursor-post.html
@@ -14,7 +14,11 @@
       <a th:if="${prevPost != null}" th:href="${prevPost.status.permalink}" class="surround-link">
         <span class="icon-[solar--rewind-back-bold-duotone] rtl-flip"></span>
         <div class="surround-text">
-          <strong class="title text-creative" th:text="${prevPost.spec.title}"></strong>
+          <strong
+            class="title text-creative"
+            th:text="${prevPost.spec.title}"
+            th:title="${prevPost.spec.title}"
+          ></strong>
           <span class="date" th:text="${#temporals.format(prevPost.spec.publishTime, 'yyyy-MM-dd')}"></span>
         </div>
       </a>
@@ -28,7 +32,11 @@
       <a th:if="${nextPost != null}" th:href="${nextPost.status.permalink}" class="surround-link align-end">
         <span class="icon-[solar--rewind-forward-bold-duotone] rtl-flip"></span>
         <div class="surround-text">
-          <strong class="title text-creative" th:text="${nextPost.spec.title}"></strong>
+          <strong
+            class="title text-creative"
+            th:text="${nextPost.spec.title}"
+            th:title="${nextPost.spec.title}"
+          ></strong>
           <span class="date" th:text="${#temporals.format(nextPost.spec.publishTime, 'yyyy-MM-dd')}"></span>
         </div>
       </a>


### PR DESCRIPTION
1. 为所有文章标题链接添加th:title属性，完整展示文章标题作为悬浮提示
2. 为多场景下的文章标题添加多行/单行省略号样式，避免文本溢出破坏布局
3. 调整标题行高优化视觉体验，适配移动端屏幕尺寸

#### 前
<img width="1361" height="569" alt="image" src="https://github.com/user-attachments/assets/ac1214e3-aa72-40fb-8d3a-6f5618101655" />

#### 后
<img width="980" height="881" alt="image" src="https://github.com/user-attachments/assets/4b34e4ce-6034-428f-ac81-cabf35f653e9" />
