### PR TITLE
fix(aside): 修复朋友圈页面不显示侧边栏

### DIFF
--- a/templates/modules/aside.html
+++ b/templates/modules/aside.html
@@ -1,13 +1,17 @@
 <th:block th:replace="~{modules/aside-widgets/aside-bgmask :: aside-bgmask}"></th:block>
 
 <aside th:fragment="aside" id="z-aside">
-  <th:block th:if="${post != null or singlePage != null or docTree != null}">
-    <!-- 目录组件 -->
+  <!-- 目录组件：仅文章页和开启 TOC 的独立页面 -->
+  <th:block
+    th:if="${post != null or docTree != null or (singlePage != null and #annotations.getOrDefault(singlePage, 'toc', 'false') == 'true')}"
+  >
     <div th:replace="~{modules/aside-widgets/toc-widget :: toc-widget}"></div>
   </th:block>
 
-  <!-- 侧边栏组件 -->
-  <th:block th:unless="${post != null or singlePage != null or docTree != null}">
+  <!-- 侧边栏组件：首页或未开启 TOC 的独立页面 -->
+  <th:block
+    th:unless="${post != null or docTree != null or (singlePage != null and #annotations.getOrDefault(singlePage, 'toc', 'false') == 'true')}"
+  >
     <th:block th:each="item : ${theme.config.aside.widgets.index}">
       <th:block th:switch="${item.widget}">
         <th:block th:case="'stats'">


### PR DESCRIPTION
### 前
<img width="2464" height="1289" alt="image" src="https://github.com/user-attachments/assets/2ca390dc-ff2a-4270-bd24-18685a416cd1" />

### 后
<img width="2464" height="1289" alt="image" src="https://github.com/user-attachments/assets/efa363eb-9f0c-4255-a871-4140509076fa" />
