### PR TITLE
feat(interaction-plus): 初步接入互动增强

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1382,6 +1382,21 @@ spec:
               label: 在文档内容启用 H1 标题
               help: 开启后文档内容将显示 H1 标题
               value: true
+        - $formkit: group
+          name: interaction_plus
+          label: 互动增强
+          help: interaction-plus
+          children:
+            - $formkit: switch
+              name: enable
+              label: 启用装扮展示
+              value: true
+              help: 作者行出用户卡，作者页展示装扮。关闭或未装插件则回退主题原样。
+            - $formkit: switch
+              name: enable_list
+              label: 在列表页启用装扮
+              value: false
+              help: 默认关闭。开启后文章列表作者行也会出用户卡。需先开总开关。
     - group: custom
       label: 自定义
       formSchema:

--- a/src/styles/scss/components/_author.scss
+++ b/src/styles/scss/components/_author.scss
@@ -14,24 +14,53 @@
     color: var(--c-primary);
   }
 
+  a {
+    display: inline-flex;
+    align-items: center;
+    color: inherit;
+    text-decoration: none;
+  }
+
   img {
     width: 1.25rem;
     height: 1.25rem;
     border-radius: 50%;
     object-fit: cover;
   }
+
+  // 盖过 .post-info img { 1em }，避免兜底头像被压小
+  .post-info & img {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+  }
+
+  hip-user-card,
+  hip-user-avatar,
+  hip-user-identity {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+  }
+
+  hip-user-card {
+    line-height: 0;
+    cursor: pointer;
+  }
 }
 
 // ========================================
-// 作者页面信息卡片
+// 作者页面信息卡片（基础 = 主题原布局）
 // ========================================
 .author-profile {
+  position: relative;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 1.5rem;
   padding: 1.5rem;
   margin-bottom: 1.5rem;
+  overflow: visible;
   border-radius: 1rem;
   background: linear-gradient(135deg, var(--c-bg-2), var(--c-bg-3));
   box-shadow: 0 0.2rem 0.5rem var(--ld-shadow);
@@ -44,6 +73,8 @@
 }
 
 .author-avatar-wrapper {
+  position: relative;
+  z-index: 1;
   flex-shrink: 0;
 }
 
@@ -78,14 +109,81 @@
 }
 
 .author-info {
+  position: relative;
+  z-index: 1;
   flex: 1;
   min-width: 180px;
 }
 
-.author-name {
+.author-name-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 0.6rem;
   margin: 0 0 0.25rem;
+
+  @media (max-width: 640px) {
+    justify-content: center;
+  }
+}
+
+.author-name {
+  margin: 0;
   font-size: 1.5rem;
   color: var(--c-text);
+}
+
+// 必须用 background-image 而不是 background 简写，否则会冲掉 clip
+.author-name--gradient {
+  background-color: transparent;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.author-primary-badge {
+  width: 1.25rem;
+  height: 1.25rem;
+  object-fit: contain;
+}
+
+.author-title {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--c-text-2);
+}
+
+.author-title-img {
+  max-width: 12rem;
+  max-height: 48px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  vertical-align: middle;
+}
+
+.author-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.15rem 0.45rem;
+  border: 1px solid var(--c-border, var(--c-text-3));
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  color: var(--c-text-2);
+}
+
+.author-mark-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  object-fit: contain;
 }
 
 .author-bio {
@@ -100,10 +198,17 @@
   flex-wrap: wrap;
   gap: 0.5rem 1.25rem;
   font-size: 0.8rem;
-  color: var(--c-text-3);
+  // 原 --c-text-3 在资料卡底色上过淡，提到 --c-text-2 保证可读性
+  color: var(--c-text-2);
 
   @media (max-width: 640px) {
     justify-content: center;
+  }
+
+  b {
+    color: var(--c-text);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
   }
 }
 
@@ -114,7 +219,7 @@
 }
 
 .meta-link {
-  color: var(--c-text-3);
+  color: var(--c-text-2);
   transition: color 0.2s;
 
   &:hover {
@@ -122,7 +227,378 @@
   }
 }
 
-// 空状态 (复用)
+// ========================================
+// 插件在场：资料卡仍用主题原横排，只叠加框 / 渐变名 / 称号
+// ========================================
+.author-banner {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  border-radius: inherit;
+  pointer-events: none;
+  // 遮罩相对卡片：从行尾实起到行首化开，换素材尺寸也不跑味
+  -webkit-mask-image: linear-gradient(to var(--start, left), #000 0%, #000 28%, transparent 72%);
+  mask-image: linear-gradient(to var(--start, left), #000 0%, #000 28%, transparent 72%);
+  -webkit-mask-size: 100% 100%;
+  mask-size: 100% 100%;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+
+  .author-banner-img {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-end: 0;
+    display: block;
+    width: 55%;
+    height: 100%;
+    max-width: none;
+    object-fit: cover;
+    object-position: var(--end, right) center;
+  }
+
+  @media (max-width: 640px) {
+    -webkit-mask-image: linear-gradient(to var(--start, left), #000 0%, #000 10%, transparent 50%);
+    mask-image: linear-gradient(to var(--start, left), #000 0%, #000 10%, transparent 50%);
+
+    .author-banner-img {
+      width: 70%;
+      opacity: 0.7;
+    }
+  }
+}
+
+.author-avatar-stack {
+  position: relative;
+  display: block;
+  width: 80px;
+  height: 80px;
+  overflow: visible;
+}
+
+.author-profile--hip .author-avatar {
+  position: absolute;
+  inset: 0;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+
+  &:hover {
+    transform: none;
+  }
+}
+
+.author-avatar-stack > .author-deco-frame {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 124%;
+  height: 124%;
+  max-width: none;
+  max-height: none;
+  object-fit: contain;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+}
+
+.author-avatar-fallback {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--c-bg-soft);
+  color: var(--c-text-3);
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.author-avatar-stack:has(.author-deco-frame) .author-avatar,
+.author-avatar-stack:has(.author-deco-frame) .author-avatar-fallback {
+  border: 0;
+  box-shadow: none;
+}
+
+.author-profile--hip .author-name-row {
+  margin-bottom: 0.25rem;
+}
+
+.author-title-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.35rem;
+}
+
+// ========================================
+// 装扮展厅：独立区块，对齐归档页头部语言
+// ========================================
+.author-gallery {
+  margin: 0 0 1.75rem;
+  overflow: visible;
+}
+
+.author-gallery-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
+}
+
+.author-gallery-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--c-text);
+
+  > span:first-child {
+    font-size: 1.1rem;
+    color: var(--c-primary);
+  }
+}
+
+.author-gallery-count {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--c-text-3);
+
+  strong {
+    color: var(--c-text);
+    font-weight: 600;
+  }
+}
+
+.author-gallery-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem 0.8rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow: visible;
+}
+
+.author-gallery-item {
+  --slot-accent: var(--wall-rarity, var(--c-border));
+  --slot-size: 6.25rem;
+
+  position: relative;
+  z-index: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  width: var(--slot-size);
+
+  &:hover,
+  &:focus-within {
+    z-index: 3;
+  }
+}
+
+.author-gallery-media {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--slot-size);
+  height: var(--slot-size);
+  min-width: 0;
+  padding: 0.5rem;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--slot-accent) 55%, var(--c-border));
+  border-radius: 0.75rem;
+  background: var(--c-bg-2);
+  box-shadow: 0 0.1rem 0.25rem var(--ld-shadow);
+  transition:
+    transform 0.2s,
+    border-color 0.2s,
+    box-shadow 0.2s;
+
+  img {
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    object-fit: contain;
+  }
+
+  .author-gallery-item:hover &,
+  .author-gallery-item:focus-within & {
+    transform: translateY(-2px);
+    border-color: var(--slot-accent);
+    box-shadow: 0 0.3rem 0.7rem var(--ld-shadow);
+  }
+}
+
+.author-gallery-fallback {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 0.1rem 0.25rem;
+  border-radius: 0.25rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.25;
+  text-align: center;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow-wrap: normal;
+  word-break: keep-all;
+}
+
+.author-gallery-item.card_background .author-gallery-media {
+  padding: 0.35rem;
+
+  img {
+    object-fit: contain;
+    object-position: center;
+  }
+}
+
+.author-gallery-item.name_style .author-gallery-fallback {
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.author-gallery-item.title .author-gallery-media {
+  padding: 0.35rem;
+
+  img {
+    object-fit: contain;
+  }
+}
+
+.author-gallery-name {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  font-size: 0.72rem;
+  line-height: 1.3;
+  color: var(--c-text-3);
+  text-align: center;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow-wrap: normal;
+  word-break: keep-all;
+}
+
+.author-gallery-pop {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.55rem);
+  z-index: 24;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: max-content;
+  max-width: min(18rem, 72vw);
+  padding: 0.7rem 0.7rem 0.6rem;
+  border: 1px solid var(--c-border);
+  border-radius: 0.85rem;
+  background: var(--ld-bg-card);
+  box-shadow: 0 0.6rem 1.6rem var(--ld-shadow);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(6px);
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease,
+    visibility 0.16s;
+}
+
+.author-gallery-item:hover .author-gallery-pop,
+.author-gallery-item:focus-within .author-gallery-pop {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+.author-gallery-pop-media {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 7.5rem;
+  min-height: 4.5rem;
+
+  img {
+    width: auto;
+    height: auto;
+    max-width: 15.5rem;
+    max-height: 8.5rem;
+    object-fit: contain;
+  }
+
+  .author-gallery-fallback {
+    font-size: 1.35rem;
+    font-weight: 700;
+    line-height: 1.35;
+    white-space: normal;
+    word-break: break-word;
+  }
+}
+
+.author-gallery-item.card_background .author-gallery-pop-media img {
+  width: 15.5rem;
+  height: auto;
+  aspect-ratio: 560 / 304;
+  object-fit: contain;
+  object-position: center top;
+  border-radius: 0.45rem;
+}
+
+.author-gallery-item.avatar_frame .author-gallery-pop-media img,
+.author-gallery-item.badge .author-gallery-pop-media img {
+  width: 7.5rem;
+  height: 7.5rem;
+  max-height: none;
+}
+
+.author-gallery-item.title .author-gallery-pop-media img {
+  max-width: 16rem;
+  max-height: 5.5rem;
+}
+
+.author-gallery-pop-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+  margin-top: 0.5rem;
+  text-align: center;
+
+  strong {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--c-text);
+  }
+
+  em {
+    font-size: 0.7rem;
+    font-style: normal;
+    color: var(--wall-rarity, var(--c-text-3));
+  }
+}
+
+@media (hover: none) {
+  .author-gallery-pop {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .author-gallery-pop,
+  .author-gallery-media {
+    transition: none;
+  }
+}
+
 .empty-state {
   display: flex;
   flex-direction: column;

--- a/src/styles/scss/components/_image.scss
+++ b/src/styles/scss/components/_image.scss
@@ -1,6 +1,13 @@
 // 图片骨架屏基础样式
 // 排除 Fancybox 灯箱内的图片 以及 twikoo 的表情包，避免样式冲突
-img:not(.fancybox__image, .tk-owo-emotion, .OwO-items-image img) {
+img:not(
+    .fancybox__image,
+    .tk-owo-emotion,
+    .OwO-items-image img,
+    .author-deco-frame,
+    .author-banner-img,
+    .author-gallery-img
+  ) {
   // 骨架屏占位
   background: linear-gradient(
     90deg,
@@ -42,7 +49,14 @@ img:not(.fancybox__image, .tk-owo-emotion, .OwO-items-image img) {
 
 // 减少动画 - 尊重用户偏好
 @media (prefers-reduced-motion: reduce) {
-  img:not(.fancybox__image, .tk-owo-emotion, .OwO-items-image img) {
+  img:not(
+      .fancybox__image,
+      .tk-owo-emotion,
+      .OwO-items-image img,
+      .author-deco-frame,
+      .author-banner-img,
+      .author-gallery-img
+    ) {
     animation: none;
   }
 }

--- a/templates/author.html
+++ b/templates/author.html
@@ -4,44 +4,250 @@
   th:replace="~{modules/layout :: html(content = ~{::content}, showAside = true, pageTitle = null, head = ~{::head})}"
 >
   <th:block th:fragment="content">
-    <div class="archive proper-height">
-      <section class="author-profile">
-        <div class="author-avatar-wrapper">
-          <img
-            th:if="${author.spec.avatar}"
-            th:src="${author.spec.avatar}"
-            th:alt="${author.spec.displayName}"
-            class="author-avatar"
-          />
-          <div th:unless="${author.spec.avatar}" class="author-avatar-placeholder">
-            <span class="icon-[ph--user-circle-bold]"></span>
+    <div
+      class="archive proper-height"
+      th:with="hipWanted=${theme.config.plugins?.interaction_plus?.enable != false}, hipEnabled=${hipWanted and pluginFinder.available('interaction-plus')}, hipId=${hipEnabled ? interactionPlus.getIdentity(author.metadata.name) : null}, hipWall=${hipEnabled ? interactionPlus.getDecorations(author.metadata.name) : null}, worn=${hipId?.decorations}"
+    >
+      <!--
+        产品闸门只看主题开关。Finder 仍必须先确认插件在场，否则 interactionPlus 未绑定会整页 500。
+        方案 D：资料卡保持主题原横排；装扮展览独立、格子统一尺寸。
+      -->
+      <section class="author-profile" th:classappend="${hipEnabled and hipId != null} ? 'author-profile--hip' : null">
+        <th:block
+          th:if="${hipEnabled and hipId != null}"
+          th:with="ns=${worn?.nameStyle?.nameStyle}, nsColors=${ns?.colors}, nsGradient=${ns != null and ns.mode == 'gradient' and nsColors != null and #lists.size(nsColors) >= 2}, nsFirst=${nsColors != null and not #lists.isEmpty(nsColors) ? nsColors[0] : null}, nsSecond=${nsColors != null and #lists.size(nsColors) > 1 ? nsColors[1] : null}, nsThird=${nsColors != null and #lists.size(nsColors) > 2 ? nsColors[2] : null}, title=${worn?.title}, showName=${hipId.displayName != null ? hipId.displayName : author.spec.displayName}, showAvatar=${hipId.avatar != null ? hipId.avatar : author.spec.avatar}, showBio=${hipId.bio != null ? hipId.bio : author.spec.bio}, joinedAt=${hipId.registeredAt != null ? hipId.registeredAt : author.spec.registeredAt}"
+        >
+          <!-- 佩戴中的名片背景：右侧定槽 cover，相对卡片向左淡出 -->
+          <div class="author-banner" th:if="${not #strings.isEmpty(worn?.cardBackground?.url)}">
+            <img
+              class="author-banner-img"
+              th:src="${worn.cardBackground.url}"
+              alt=""
+              onerror="this.parentElement.remove()"
+            />
           </div>
-        </div>
 
-        <div class="author-info">
-          <h1 class="author-name text-creative" th:text="${author.spec.displayName}"></h1>
-
-          <p th:if="${author.spec.bio}" class="author-bio" th:text="${author.spec.bio}"></p>
-
-          <div class="author-meta">
-            <span th:if="${author.spec.registeredAt}" class="meta-item">
-              <span class="icon-[ph--calendar-dots-bold]"></span>
-              <span>加入于 </span>
-              <time th:text="${#temporals.format(author.spec.registeredAt, 'yyyy-MM-dd')}"></time>
+          <div class="author-avatar-wrapper">
+            <span class="author-avatar-stack">
+              <span
+                class="author-avatar-fallback"
+                th:text="${#strings.isEmpty(showName) ? '?' : #strings.toUpperCase(#strings.substring(showName, 0, 1))}"
+              ></span>
+              <img
+                th:if="${showAvatar}"
+                class="author-avatar"
+                th:src="${showAvatar}"
+                th:alt="${showName}"
+                onerror="this.style.display='none'"
+              />
+              <img
+                th:if="${worn?.avatarFrame?.url}"
+                class="author-deco-frame"
+                th:src="${worn.avatarFrame.url}"
+                alt=""
+                onerror="this.style.display='none'"
+              />
             </span>
-
-            <span class="meta-item">
-              <span class="icon-[ph--article-bold]"></span>
-              <span th:text="${posts.total}"></span>
-              <span> 篇文章</span>
-            </span>
-
-            <a th:if="${author.spec.email}" th:href="'mailto:' + ${author.spec.email}" class="meta-item meta-link">
-              <span class="icon-[ph--envelope-simple-bold]"></span>
-              <span th:text="${author.spec.email}"></span>
-            </a>
           </div>
-        </div>
+
+          <div class="author-info">
+            <div class="author-name-row">
+              <h1
+                class="author-name text-creative"
+                th:text="${showName}"
+                th:classappend="${nsGradient} ? 'author-name--gradient' : null"
+                th:style="${nsGradient} ? (${nsThird != null} ? |background-image:linear-gradient(90deg, ${nsFirst}, ${nsSecond}, ${nsThird});color:${nsFirst}| : |background-image:linear-gradient(90deg, ${nsFirst}, ${nsSecond});color:${nsFirst}|) : (${nsFirst != null} ? |color:${nsFirst}| : null)"
+              ></h1>
+              <th:block th:if="${hipId.identityMarks != null and not #lists.isEmpty(hipId.identityMarks)}">
+                <th:block th:each="mark : ${hipId.identityMarks}">
+                  <img
+                    th:if="${mark.icon != null}"
+                    class="author-mark-icon"
+                    th:src="${mark.icon}"
+                    th:alt="${mark.displayName}"
+                    th:title="${mark.displayName}"
+                    onerror="this.style.display='none';var n=this.nextElementSibling;if(n)n.style.display=''"
+                  />
+                  <span
+                    th:if="${mark.icon != null}"
+                    class="author-mark"
+                    style="display: none"
+                    th:text="${mark.displayName}"
+                  ></span>
+                  <span
+                    th:unless="${mark.icon != null}"
+                    class="author-mark"
+                    th:text="${mark.displayName}"
+                    th:style="${mark.color != null} ? |color:${mark.color};border-color:${mark.color}| : null"
+                  ></span>
+                </th:block>
+              </th:block>
+              <img
+                th:if="${worn?.primaryBadge?.url}"
+                class="author-primary-badge"
+                th:src="${worn.primaryBadge.url}"
+                th:alt="${worn.primaryBadge.displayName}"
+                th:title="${worn.primaryBadge.displayName}"
+                onerror="this.style.display='none'"
+              />
+            </div>
+
+            <div class="author-title-row" th:if="${title != null and title.titleText != null}">
+              <img
+                th:if="${not #strings.isEmpty(title.url)}"
+                class="author-title-img"
+                th:src="${title.url}"
+                th:alt="${title.titleText}"
+                th:title="${title.titleText}"
+                onerror="this.style.display='none';var n=this.nextElementSibling;if(n)n.style.display=''"
+              />
+              <span
+                class="author-title"
+                th:if="${#strings.isEmpty(title.url)}"
+                th:text="${title.titleText}"
+                th:style="${title.titleBackground != null and title.titleBackgroundSecondary != null} ? (${title.titleColor != null} ? |color:${title.titleColor};background-image:linear-gradient(135deg, ${title.titleBackground}, ${title.titleBackgroundSecondary})| : |background-image:linear-gradient(135deg, ${title.titleBackground}, ${title.titleBackgroundSecondary})|) : (${title.titleBackground != null} ? (${title.titleColor != null} ? |color:${title.titleColor};background-color:${title.titleBackground}| : |background-color:${title.titleBackground}|) : (${title.titleColor != null} ? |color:${title.titleColor}| : null))"
+              ></span>
+              <!-- 裂图时再露出文字称号 -->
+              <span
+                class="author-title"
+                style="display: none"
+                th:if="${not #strings.isEmpty(title.url)}"
+                th:text="${title.titleText}"
+              ></span>
+            </div>
+
+            <p th:if="${showBio}" class="author-bio" th:text="${showBio}"></p>
+
+            <div class="author-meta">
+              <span th:if="${joinedAt}" class="meta-item">
+                <span>加入于 </span>
+                <time th:text="${#temporals.format(joinedAt, 'yyyy-MM-dd')}"></time>
+              </span>
+              <span th:if="${hipId.stats != null}" class="meta-item">
+                <b th:text="${hipId.stats.posts}"></b>
+                <span> 篇文章</span>
+              </span>
+              <span th:if="${hipId.stats != null}" class="meta-item">
+                <b th:text="${hipId.stats.comments}"></b>
+                <span> 条评论</span>
+              </span>
+              <span th:if="${hipId.stats != null and hipId.stats.decorations != null}" class="meta-item">
+                <b th:text="${hipId.stats.decorations.badge}"></b>
+                <span> 枚勋章</span>
+              </span>
+              <span
+                class="meta-item"
+                th:each="extra : ${hipId.stats?.extras}"
+                th:if="${extra.label != null and extra.value != null}"
+              >
+                <b th:text="${extra.value}"></b>
+                <span th:text="' ' + ${extra.label}"></span>
+              </span>
+              <a th:if="${author.spec.email}" th:href="'mailto:' + ${author.spec.email}" class="meta-item meta-link">
+                <span th:text="${author.spec.email}"></span>
+              </a>
+            </div>
+          </div>
+        </th:block>
+
+        <th:block th:unless="${hipEnabled and hipId != null}">
+          <div class="author-avatar-wrapper">
+            <img
+              th:if="${author.spec.avatar}"
+              th:src="${author.spec.avatar}"
+              th:alt="${author.spec.displayName}"
+              class="author-avatar"
+            />
+            <div th:unless="${author.spec.avatar}" class="author-avatar-placeholder">
+              <span class="icon-[ph--user-circle-bold]"></span>
+            </div>
+          </div>
+          <div class="author-info">
+            <h1 class="author-name text-creative" th:text="${author.spec.displayName}"></h1>
+            <p th:if="${author.spec.bio}" class="author-bio" th:text="${author.spec.bio}"></p>
+            <div class="author-meta">
+              <span th:if="${author.spec.registeredAt}" class="meta-item">
+                <span class="icon-[ph--calendar-dots-bold]"></span>
+                <span>加入于 </span>
+                <time th:text="${#temporals.format(author.spec.registeredAt, 'yyyy-MM-dd')}"></time>
+              </span>
+              <span class="meta-item">
+                <span class="icon-[ph--article-bold]"></span>
+                <span th:text="${posts.total}"></span>
+                <span> 篇文章</span>
+              </span>
+              <a th:if="${author.spec.email}" th:href="'mailto:' + ${author.spec.email}" class="meta-item meta-link">
+                <span class="icon-[ph--envelope-simple-bold]"></span>
+                <span th:text="${author.spec.email}"></span>
+              </a>
+            </div>
+          </div>
+        </th:block>
+      </section>
+
+      <section
+        class="author-gallery"
+        th:if="${hipEnabled and hipId != null and hipWall != null and not #lists.isEmpty(hipWall)}"
+        th:with="wallName=${hipId.displayName != null ? hipId.displayName : author.spec.displayName}"
+      >
+        <header class="author-gallery-head">
+          <h2 class="author-gallery-title">
+            <span class="icon-[ph--confetti-bold]"></span>
+            <span>装扮展览</span>
+          </h2>
+          <p class="author-gallery-count">共 <strong th:text="${#lists.size(hipWall)}">0</strong> 件</p>
+        </header>
+        <ul class="author-gallery-grid">
+          <li
+            th:each="d : ${hipWall}"
+            class="author-gallery-item"
+            th:classappend="${d.type}"
+            tabindex="0"
+            th:with="dNs=${d.nameStyle}, dColors=${dNs?.colors}, dGrad=${d.type == 'name_style' and dNs != null and dNs.mode == 'gradient' and dColors != null and #lists.size(dColors) >= 2}, dFirst=${dColors != null and not #lists.isEmpty(dColors) ? dColors[0] : null}, dSecond=${dColors != null and #lists.size(dColors) > 1 ? dColors[1] : null}, dThird=${dColors != null and #lists.size(dColors) > 2 ? dColors[2] : null}, faceName=${d.type == 'name_style' ? (#strings.isEmpty(wallName) ? 'Aa' : wallName) : (d.type == 'title' and d.titleText != null ? d.titleText : d.displayName)}, faceHide=${not #strings.isEmpty(d.url)}, faceCss=${dGrad} ? (${dThird != null} ? |background-image:linear-gradient(90deg, ${dFirst}, ${dSecond}, ${dThird});color:${dFirst}| : |background-image:linear-gradient(90deg, ${dFirst}, ${dSecond});color:${dFirst}|) : (${d.type == 'name_style' and dFirst != null} ? |color:${dFirst}| : (${d.type == 'title' and d.titleBackground != null and d.titleBackgroundSecondary != null} ? (${d.titleColor != null} ? |color:${d.titleColor};background-image:linear-gradient(135deg, ${d.titleBackground}, ${d.titleBackgroundSecondary})| : |background-image:linear-gradient(135deg, ${d.titleBackground}, ${d.titleBackgroundSecondary})|) : (${d.type == 'title' and d.titleBackground != null} ? (${d.titleColor != null} ? |color:${d.titleColor};background-color:${d.titleBackground}| : |background-color:${d.titleBackground}|) : (${d.titleColor != null} ? |color:${d.titleColor}| : null))))"
+            th:style="${d.rarityColor != null} ? |--wall-rarity:${d.rarityColor}| : null"
+            th:title="${d.rarityDisplayName != null} ? |${d.displayName} · ${d.rarityDisplayName}| : ${d.displayName}"
+          >
+            <span class="author-gallery-media">
+              <img
+                th:if="${not #strings.isEmpty(d.url)}"
+                class="author-gallery-img"
+                th:src="${d.url}"
+                th:alt="${d.displayName}"
+                loading="lazy"
+                onerror="this.style.display='none';var n=this.nextElementSibling;if(n)n.style.display=''"
+              />
+              <span
+                class="author-gallery-fallback"
+                th:classappend="${dGrad} ? 'author-name--gradient' : null"
+                th:text="${faceName}"
+                th:style="${faceHide} ? (${faceCss != null} ? |display:none;${faceCss}| : 'display:none') : ${faceCss}"
+              ></span>
+            </span>
+            <span class="author-gallery-name" th:text="${d.displayName}"></span>
+            <span class="author-gallery-pop" aria-hidden="true">
+              <span class="author-gallery-pop-media">
+                <img
+                  th:if="${not #strings.isEmpty(d.url)}"
+                  class="author-gallery-img no-lightbox"
+                  th:src="${d.url}"
+                  alt=""
+                  loading="lazy"
+                  onerror="this.style.display='none';var n=this.nextElementSibling;if(n)n.style.display=''"
+                />
+                <span
+                  class="author-gallery-fallback"
+                  th:classappend="${dGrad} ? 'author-name--gradient' : null"
+                  th:text="${faceName}"
+                  th:style="${faceHide} ? (${faceCss != null} ? |display:none;${faceCss}| : 'display:none') : ${faceCss}"
+                ></span>
+              </span>
+              <span class="author-gallery-pop-meta">
+                <strong th:text="${d.displayName}"></strong>
+                <em th:if="${d.rarityDisplayName}" th:text="${d.rarityDisplayName}"></em>
+              </span>
+            </span>
+          </li>
+        </ul>
       </section>
 
       <menu class="archive-list">

--- a/templates/modules/author-capsule.html
+++ b/templates/modules/author-capsule.html
@@ -1,9 +1,24 @@
-<a
-  th:fragment="capsule(author)"
+<th:block
+  th:fragment="capsule(author, inList)"
   th:if="${author != null and author.displayName != null}"
-  th:href="${author.permalink}"
-  class="author-capsule"
+  th:with="hipEnabled=${theme.config.plugins?.interaction_plus?.enable != false and pluginFinder.available('interaction-plus') and author.name != null and (inList != true or theme.config.plugins?.interaction_plus?.enable_list == true)}"
 >
-  <img th:if="${author.avatar != null}" th:src="${author.avatar}" th:alt="${author.displayName}" loading="lazy" />
-  <span th:text="${author.displayName}"></span>
-</a>
+  <!-- 总开关开、插件在场：组件自己画头像 + 框，点头像出卡；scene 按文档推荐词表区分列表 / 正文 -->
+  <span th:if="${hipEnabled}" class="author-capsule" style="--hip-avatar-size: 1.25rem">
+    <hip-user-card th:attr="user-name=${author.name}" th:scene="${inList == true} ? 'list' : 'post'">
+      <hip-user-avatar
+        th:attr="user-name=${author.name}"
+        th:scene="${inList == true} ? 'list' : 'post'"
+      ></hip-user-avatar>
+    </hip-user-card>
+    <hip-user-identity
+      th:attr="user-name=${author.name}"
+      th:scene="${inList == true} ? 'list' : 'post'"
+    ></hip-user-identity>
+  </span>
+  <!-- 未启用 / 插件未装 / 列表开关关：主题原链接胶囊 -->
+  <a th:unless="${hipEnabled}" th:href="${author.permalink}" class="author-capsule">
+    <img th:if="${author.avatar != null}" th:src="${author.avatar}" th:alt="${author.displayName}" loading="lazy" />
+    <span th:text="${author.displayName}"></span>
+  </a>
+</th:block>

--- a/templates/modules/layout.html
+++ b/templates/modules/layout.html
@@ -97,6 +97,12 @@
         }
       })();
     </script>
+    <!-- interaction-plus：主题开关开启且插件已启用时才注册 hip-*（资源地址含插件版本号，由 Finder 提供） -->
+    <th:block
+      th:if="${pluginFinder.available('interaction-plus') and (theme.config.plugins?.interaction_plus?.enable != false)}"
+    >
+      <script th:src="${interactionPlus.getRuntimeUrl()}"></script>
+    </th:block>
   </head>
   <body id="clarity-root">
     <div

--- a/templates/modules/post-list.html
+++ b/templates/modules/post-list.html
@@ -54,7 +54,7 @@
             </span>
 
             <th:block th:if="${theme.config.style.show_post_author != false}">
-              <th:block th:replace="~{modules/author-capsule :: capsule(author=${post.owner})}" />
+              <th:block th:replace="~{modules/author-capsule :: capsule(author=${post.owner}, inList=true)}" />
             </th:block>
           </div>
         </div>

--- a/templates/modules/post/post-header.html
+++ b/templates/modules/post/post-header.html
@@ -23,7 +23,7 @@
       </div>
 
       <div class="post-info">
-        <th:block th:replace="~{modules/author-capsule :: capsule(author=${post.owner})}" />
+        <th:block th:replace="~{modules/author-capsule :: capsule(author=${post.owner}, inList=false)}" />
 
         <span th:if="${post.spec.publishTime}">
           <span class="icon-[ph--calendar-dots-bold]"></span>

--- a/templates/page.html
+++ b/templates/page.html
@@ -24,7 +24,7 @@
         </div>
 
         <div class="post-info">
-          <th:block th:replace="~{modules/author-capsule :: capsule(author=${singlePage.owner})}" />
+          <th:block th:replace="~{modules/author-capsule :: capsule(author=${singlePage.owner}, inList=false)}" />
 
           <span th:if="${singlePage.spec.publishTime}">
             <span class="icon-[ph--calendar-dots-bold]"></span>


### PR DESCRIPTION
## 摘要

初步接入互动增强（[interaction-plus](https://github.com/Tim0x0/halo-plugin-interaction-plus) v1.0.0）。插件未安装或关闭开关时，作者行与作者页完全回退主题原样。

## 接入范围

- **作者行**：文章 / 页面头部走 `hip-user-card` + `hip-user-avatar` + `hip-user-identity`，点头像出用户卡。Runtime 经 `${interactionPlus.getRuntimeUrl()}` 引入。
- **作者页**：Finder SSR 自绘资料卡（头像框 / 昵称样式 / 称号 / 身份标识 / 名片背景）与装扮展览。
- **列表页**：默认关闭。开启后首页、分类、标签等文章列表作者行也会出用户卡。

## 主题设置

「插件适配 → 互动增强」：

- 启用装扮展示（默认开）
- 在列表页启用装扮（默认关）

## 说明

渲染一律用插件内置组件，不内嵌主题自定义 `data-hip` 模板。